### PR TITLE
feat: add @tanstack/shallow library to the workspace

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   "pnpm": {
     "overrides": {
       "@tanstack/store": "workspace:*",
+      "@tanstack/shallow": "workspace:*",
       "@tanstack/react-store": "workspace:*"
     },
     "patchedDependencies": {

--- a/packages/react-store/src/index.tsx
+++ b/packages/react-store/src/index.tsx
@@ -2,6 +2,7 @@ import type { AnyUpdater, Store } from '@tanstack/store'
 import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector.js'
 
 export * from '@tanstack/store'
+import { shallow } from '@tanstack/shallow'
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
@@ -22,34 +23,4 @@ export function useStore<
   )
 
   return slice
-}
-
-export function shallow<T>(objA: T, objB: T) {
-  if (Object.is(objA, objB)) {
-    return true
-  }
-
-  if (
-    typeof objA !== 'object' ||
-    objA === null ||
-    typeof objB !== 'object' ||
-    objB === null
-  ) {
-    return false
-  }
-
-  const keysA = Object.keys(objA)
-  if (keysA.length !== Object.keys(objB).length) {
-    return false
-  }
-
-  for (let i = 0; i < keysA.length; i++) {
-    if (
-      !Object.prototype.hasOwnProperty.call(objB, keysA[i] as string) ||
-      !Object.is(objA[keysA[i] as keyof T], objB[keysA[i] as keyof T])
-    ) {
-      return false
-    }
-  }
-  return true
 }

--- a/packages/shallow/.eslintrc.cjs
+++ b/packages/shallow/.eslintrc.cjs
@@ -1,0 +1,11 @@
+// @ts-check
+
+/** @type {import('eslint').Linter.Config} */
+const config = {
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.json',
+  },
+}
+
+module.exports = config

--- a/packages/shallow/package.json
+++ b/packages/shallow/package.json
@@ -1,23 +1,11 @@
 {
-  "name": "@tanstack/react-store",
+  "name": "@tanstack/shallow",
   "author": "Tanner Linsley",
   "version": "0.1.3",
   "license": "MIT",
-  "repository": "tanstack/react-store",
-  "homepage": "https://tanstack.com/",
+  "repository": "tanstack/store",
+  "homepage": "https://tanstack.com/store",
   "description": "",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "keywords": [
-    "store",
-    "react",
-    "typescript"
-  ],
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/tannerlinsley"
-  },
   "scripts": {
     "clean": "rimraf ./build && rimraf ./coverage",
     "test:eslint": "eslint --ext .ts,.tsx ./src",
@@ -27,10 +15,17 @@
     "test:build": "publint --strict",
     "build": "tsup"
   },
-  "files": [
-    "build",
-    "src"
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
+  },
+  "keywords": [
+    "store",
+    "typescript"
   ],
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
   "type": "module",
   "types": "build/legacy/index.d.ts",
   "main": "build/legacy/index.cjs",
@@ -49,16 +44,8 @@
     "./package.json": "./package.json"
   },
   "sideEffects": false,
-  "peerDependencies": {
-    "react": ">=16",
-    "react-dom": ">=16"
-  },
-  "dependencies": {
-    "@tanstack/shallow": "workspace:^0.1.3",
-    "@tanstack/store": "workspace:*",
-    "use-sync-external-store": "^1.2.0"
-  },
-  "devDependencies": {
-    "@types/use-sync-external-store": "^0.0.3"
-  }
+  "files": [
+    "build",
+    "src"
+  ]
 }

--- a/packages/shallow/src/__tests__/index.test.tsx
+++ b/packages/shallow/src/__tests__/index.test.tsx
@@ -1,0 +1,55 @@
+import { describe, test, expect } from 'vitest'
+import { shallow } from '../index'
+
+describe('shallow', () => {
+  test('should return true for shallowly equal objects', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, b: 'hello' }
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different values', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 2, b: 'world' }
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different keys', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, c: 'world' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different structures', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = [1, 'hello']
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being null', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = null
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being undefined', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = undefined
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return true for two null objects', () => {
+    const objA = null
+    const objB = null
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different types', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: '1', b: 'hello' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+})

--- a/packages/shallow/src/index.ts
+++ b/packages/shallow/src/index.ts
@@ -1,0 +1,29 @@
+export function shallow<T>(objA: T, objB: T) {
+  if (Object.is(objA, objB)) {
+    return true
+  }
+
+  if (
+    typeof objA !== 'object' ||
+    objA === null ||
+    typeof objB !== 'object' ||
+    objB === null
+  ) {
+    return false
+  }
+
+  const keysA = Object.keys(objA)
+  if (keysA.length !== Object.keys(objB).length) {
+    return false
+  }
+
+  for (let i = 0; i < keysA.length; i++) {
+    if (
+      !Object.prototype.hasOwnProperty.call(objB, keysA[i] as string) ||
+      !Object.is(objA[keysA[i] as keyof T], objB[keysA[i] as keyof T])
+    ) {
+      return false
+    }
+  }
+  return true
+}

--- a/packages/shallow/tsconfig.json
+++ b/packages/shallow/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "types": ["vitest/globals"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", ".eslintrc.cjs", "tsup.config.js"]
+}

--- a/packages/shallow/tsup.config.js
+++ b/packages/shallow/tsup.config.js
@@ -1,0 +1,9 @@
+// @ts-check
+
+import { defineConfig } from 'tsup'
+import { legacyConfig, modernConfig } from '../../scripts/getTsupConfig.js'
+
+export default defineConfig([
+  modernConfig({ entry: ['src/*.ts'] }),
+  legacyConfig({ entry: ['src/*.ts'] }),
+])

--- a/packages/shallow/vitest.config.ts
+++ b/packages/shallow/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    name: 'shallow',
+    dir: './src',
+    watch: false,
+    globals: true,
+    coverage: { provider: 'istanbul' },
+  },
+})

--- a/packages/vue-store/package.json
+++ b/packages/vue-store/package.json
@@ -58,6 +58,7 @@
     "src"
   ],
   "dependencies": {
+    "@tanstack/shallow": "workspace:^0.1.3",
     "@tanstack/store": "workspace:*",
     "vue-demi": "^0.14.6"
   },

--- a/packages/vue-store/src/index.ts
+++ b/packages/vue-store/src/index.ts
@@ -2,6 +2,7 @@ import type { AnyUpdater, Store } from '@tanstack/store'
 import { readonly, type Ref, ref, toRaw, watch } from 'vue-demi'
 
 export * from '@tanstack/store'
+import { shallow } from '@tanstack/shallow'
 
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
@@ -34,34 +35,4 @@ export function useStore<
   )
 
   return readonly(slice) as never
-}
-
-export function shallow<T>(objA: T, objB: T) {
-  if (Object.is(objA, objB)) {
-    return true
-  }
-
-  if (
-    typeof objA !== 'object' ||
-    objA === null ||
-    typeof objB !== 'object' ||
-    objB === null
-  ) {
-    return false
-  }
-
-  const keysA = Object.keys(objA)
-  if (keysA.length !== Object.keys(objB).length) {
-    return false
-  }
-
-  for (let i = 0; i < keysA.length; i++) {
-    if (
-      !Object.prototype.hasOwnProperty.call(objB, keysA[i] as string) ||
-      !Object.is(objA[keysA[i] as keyof T], objB[keysA[i] as keyof T])
-    ) {
-      return false
-    }
-  }
-  return true
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@tanstack/store': workspace:*
+  '@tanstack/shallow': workspace:*
   '@tanstack/react-store': workspace:*
 
 patchedDependencies:
@@ -182,6 +183,9 @@ importers:
 
   packages/react-store:
     dependencies:
+      '@tanstack/shallow':
+        specifier: workspace:*
+        version: link:../shallow
       '@tanstack/store':
         specifier: workspace:*
         version: link:../store
@@ -199,10 +203,15 @@ importers:
         specifier: ^0.0.3
         version: 0.0.3
 
+  packages/shallow: {}
+
   packages/store: {}
 
   packages/vue-store:
     dependencies:
+      '@tanstack/shallow':
+        specifier: workspace:*
+        version: link:../shallow
       '@tanstack/store':
         specifier: workspace:*
         version: link:../store


### PR DESCRIPTION
It seems that you will reuse this shallow comparison function on any adapter, so to avoid some copy/paste and make sure that we use the same approach on any adapter, my idea is to add a shallow library and reuse it on all adapters. Probably @tashstack/shallow is not a good name because it is too generic, but let me know your thoughts on it.