### PR TITLE
test(react-store,vue-store): add test for shallow function on both react/vue adapters

### DIFF
--- a/packages/react-store/src/__tests__/index.test.tsx
+++ b/packages/react-store/src/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { render, waitFor } from '@testing-library/react'
 import '@testing-library/jest-dom'
 import * as React from 'react'
 import { Store } from '@tanstack/store'
-import { useStore } from '../index'
+import { useStore, shallow } from '../index'
 import { useState } from 'react'
 import userEvent from '@testing-library/user-event'
 
@@ -75,5 +75,58 @@ describe('useStore', () => {
 
     await user.click(getByText('Update ignored'))
     expect(getByText('Number rendered: 2')).toBeInTheDocument()
+  })
+})
+
+describe('shallow', () => {
+  test('should return true for shallowly equal objects', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, b: 'hello' }
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different values', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 2, b: 'world' }
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different keys', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, c: 'world' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different structures', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = [1, 'hello']
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being null', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = null
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being undefined', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = undefined
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return true for two null objects', () => {
+    const objA = null
+    const objB = null
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different types', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: '1', b: 'hello' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
   })
 })

--- a/packages/vue-store/src/__tests__/index.test.tsx
+++ b/packages/vue-store/src/__tests__/index.test.tsx
@@ -2,7 +2,7 @@ import { h, defineComponent, watch } from 'vue-demi'
 import { render, waitFor } from '@testing-library/vue'
 import '@testing-library/jest-dom'
 import { Store } from '@tanstack/store'
-import { useStore } from '../index'
+import { useStore, shallow } from '../index'
 import userEvent from '@testing-library/user-event'
 
 const user = userEvent.setup()
@@ -77,5 +77,58 @@ describe('useStore', () => {
 
     await user.click(getByText('Update ignored'))
     expect(getByText('Number rendered: 2')).toBeInTheDocument()
+  })
+})
+
+describe('shallow', () => {
+  test('should return true for shallowly equal objects', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, b: 'hello' }
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different values', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 2, b: 'world' }
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different keys', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: 1, c: 'world' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for objects with different structures', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = [1, 'hello']
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being null', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = null
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return false for one object being undefined', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = undefined
+    expect(shallow(objA, objB)).toBe(false)
+  })
+
+  test('should return true for two null objects', () => {
+    const objA = null
+    const objB = null
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
+  test('should return false for objects with different types', () => {
+    const objA = { a: 1, b: 'hello' }
+    const objB = { a: '1', b: 'hello' }
+    // @ts-ignore
+    expect(shallow(objA, objB)).toBe(false)
   })
 })


### PR DESCRIPTION
This PR adds tests to cover `shallow` function on both `react` and `vue` adapters.