### PR TITLE
feat: add ability to pass value to listeners

### DIFF
--- a/packages/store/src/index.ts
+++ b/packages/store/src/index.ts
@@ -1,15 +1,16 @@
 export type AnyUpdater = (...args: any[]) => any
 
-export type Listener = () => void
+export type Listener<T> = (val?: T) => void
 
 interface StoreOptions<
   TState,
   TUpdater extends AnyUpdater = (cb: TState) => TState,
+  TListener extends Listener<any> = Listener<void>,
 > {
   updateFn?: (previous: TState) => (updater: TUpdater) => TState
   onSubscribe?: (
-    listener: Listener,
-    store: Store<TState, TUpdater>,
+    listener: TListener,
+    store: Store<TState, TUpdater, TListener>,
   ) => () => void
   onUpdate?: () => void
 }
@@ -17,19 +18,23 @@ interface StoreOptions<
 export class Store<
   TState,
   TUpdater extends AnyUpdater = (cb: TState) => TState,
+  TListener extends Listener<any> = Listener<void>,
 > {
-  listeners = new Set<Listener>()
+  listeners = new Set<TListener>()
   state: TState
-  options?: StoreOptions<TState, TUpdater>
+  options?: StoreOptions<TState, TUpdater, TListener>
   _batching = false
   _flushing = 0
 
-  constructor(initialState: TState, options?: StoreOptions<TState, TUpdater>) {
+  constructor(
+    initialState: TState,
+    options?: StoreOptions<TState, TUpdater, TListener>,
+  ) {
     this.state = initialState
     this.options = options
   }
 
-  subscribe = (listener: Listener) => {
+  subscribe = (listener: TListener) => {
     this.listeners.add(listener)
     const unsub = this.options?.onSubscribe?.(listener, this)
     return () => {
@@ -38,7 +43,7 @@ export class Store<
     }
   }
 
-  setState = (updater: TUpdater) => {
+  setState = (updater: TUpdater, listenerVal?: Parameters<TListener>[0]) => {
     const previous = this.state
     this.state = this.options?.updateFn
       ? this.options.updateFn(previous)(updater)
@@ -48,23 +53,23 @@ export class Store<
     this.options?.onUpdate?.()
 
     // Attempt to flush
-    this._flush()
+    this._flush(listenerVal)
   }
 
-  _flush = () => {
+  _flush = (val: Parameters<TListener>[0]) => {
     if (this._batching) return
     const flushId = ++this._flushing
     this.listeners.forEach((listener) => {
       if (this._flushing !== flushId) return
-      listener()
+      listener(val)
     })
   }
 
-  batch = (cb: () => void) => {
+  batch = (cb: () => void, listenerVal?: Parameters<TListener>[0]) => {
     if (this._batching) return cb()
     this._batching = true
     cb()
     this._batching = false
-    this._flush()
+    this._flush(listenerVal)
   }
 }

--- a/packages/store/src/tests/index.test.tsx
+++ b/packages/store/src/tests/index.test.tsx
@@ -80,4 +80,52 @@ describe('store', () => {
     // Listener is called 4 times because of a lack of batching
     expect(listener).toHaveBeenCalledTimes(5)
   })
+
+  test('should allow us to pass a flush a value to listeners if we want to', () => {
+    const store = new Store<
+      number,
+      (cb: number) => number,
+      (val: number) => void
+    >(0)
+
+    const listener = vi.fn()
+
+    store.subscribe(listener)
+
+    store._flush(123)
+
+    expect(listener).toHaveBeenCalledWith(123)
+  })
+
+  test('should allow us to pass a batch a value to listeners if we want to', () => {
+    const store = new Store<
+      number,
+      (cb: number) => number,
+      (val: number) => void
+    >(0)
+
+    const listener = vi.fn()
+
+    store.subscribe(listener)
+
+    store.batch(() => {}, 123)
+
+    expect(listener).toHaveBeenCalledWith(123)
+  })
+
+  test('should allow us to pass a setState a value to listeners if we want to', () => {
+    const store = new Store<
+      number,
+      (cb: number) => number,
+      (val: number) => void
+    >(0)
+
+    const listener = vi.fn()
+
+    store.subscribe(listener)
+
+    store.setState(() => 234, 123)
+
+    expect(listener).toHaveBeenCalledWith(123)
+  })
 })


### PR DESCRIPTION
This PR adds the ability to pass a value to our listeners (optionally) thru our APIs.

This is not _really_ intended to be used by the general public, but rather for our needs internally, IE refactoring the `Subscribable` class in TanStack Query:

https://github.com/TanStack/query/pull/6799

**This has no breaking changes, and is a purely additive change**