### PR TITLE
ci: Run Nx Agents on `ci.yml`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,15 @@ jobs:
         with:
           node-version-file: .nvmrc
           cache: pnpm
+      - name: Start Nx Agents
+        run: npx nx-cloud start-ci-run --distribute-on=".nx/workflows/dynamic-changesets.yaml"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Tests
-        run: pnpm run test:ci
+        run: pnpm run test:ci --parallel=3
+      - name: Stop Agents
+        if: ${{ always() }}
+        run: npx nx-cloud stop-all-agents
       - name: Publish
         run: |
           git config --global user.name 'Tanner Linsley'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run Tests
         run: pnpm run test:ci --parallel=3
-      - name: Stop Agents
+      - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents
       - name: Publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,6 +42,8 @@ jobs:
           main-branch-name: 'main'
       - name: Run Checks
         run: pnpm run test:pr --parallel=3
+      - name: Test if dist files present in github
+        run: cat ./packages/react-store/dist/esm/index.js
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -42,8 +42,6 @@ jobs:
           main-branch-name: 'main'
       - name: Run Checks
         run: pnpm run test:pr --parallel=3
-      - name: Test if dist files present in github
-        run: cat ./packages/react-store/dist/esm/index.js
       - name: Stop Nx Agents
         if: ${{ always() }}
         run: npx nx-cloud stop-all-agents


### PR DESCRIPTION
This may not work depending on if cached outputs get downloaded by the GitHub workflow.