### PR TITLE
Fix repo link in npm

### DIFF
--- a/packages/react-store/package.json
+++ b/packages/react-store/package.json
@@ -3,7 +3,7 @@
   "author": "Tanner Linsley",
   "version": "0.3.1",
   "license": "MIT",
-  "repository": "tanstack/react-store",
+  "repository": "tanstack/store",
   "homepage": "https://tanstack.com/",
   "description": "",
   "publishConfig": {

--- a/packages/solid-store/package.json
+++ b/packages/solid-store/package.json
@@ -3,7 +3,7 @@
   "author": "Tanner Linsley",
   "version": "0.3.1",
   "license": "MIT",
-  "repository": "tanstack/solid-store",
+  "repository": "tanstack/store",
   "homepage": "https://tanstack.com/",
   "description": "",
   "publishConfig": {

--- a/packages/vue-store/package.json
+++ b/packages/vue-store/package.json
@@ -3,7 +3,7 @@
   "version": "0.3.1",
   "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/react-store",
+  "repository": "tanstack/store",
   "homepage": "https://tanstack.com/",
   "description": "",
   "publishConfig": {


### PR DESCRIPTION
This PR fixes the old rep link in npm

![image](https://github.com/TanStack/store/assets/82659015/6f974e3b-427c-40bb-a987-0a83775aa3a4)
