### PR TITLE
chore: Enable link-workspace-packages

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
+link-workspace-packages=true
 prefer-workspace-packages=true


### PR DESCRIPTION
- Default setting changed to false in pnpm v9
- Fixes local development of examples