### PR TITLE
chore: Remove browserslistrc

### DIFF
--- a/.browserslistrc
+++ b/.browserslistrc
@@ -1,7 +1,0 @@
-# Browsers we support
-Chrome >= 84
-Firefox >= 90
-Edge >= 84
-Safari >= 15
-iOS >= 15
-opera >= 70


### PR DESCRIPTION
This was added in the initial commit for this repo, and wasn't removed (i.e. I missed it) when babel/rollup were replaced with vite