### PR TITLE
fix: Add correct `"repository"` field to `package.json`

### DIFF
--- a/packages/angular-store/package.json
+++ b/packages/angular-store/package.json
@@ -1,11 +1,24 @@
 {
   "name": "@tanstack/angular-store",
-  "author": "Tanner Linsley",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
+  "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/store",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/store.git",
+    "directory": "packages/angular-store"
+  },
   "homepage": "https://tanstack.com/store",
-  "description": "",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "keywords": [
+    "store",
+    "typescript",
+    "angular"
+  ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint ./src ./tests",
@@ -14,18 +27,6 @@
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "ng-packagr -p ng-package.json -c tsconfig.build.json && rimraf ./dist/package.json"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "keywords": [
-    "store",
-    "typescript",
-    "angular"
-  ],
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
   "types": "dist/index.d.ts",

--- a/packages/react-store/package.json
+++ b/packages/react-store/package.json
@@ -1,23 +1,24 @@
 {
   "name": "@tanstack/react-store",
-  "author": "Tanner Linsley",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
+  "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/store",
-  "homepage": "https://tanstack.com/",
-  "description": "",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/store.git",
+    "directory": "packages/react-store"
+  },
+  "homepage": "https://tanstack.com/store",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
   },
   "keywords": [
     "store",
     "react",
     "typescript"
   ],
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/tannerlinsley"
-  },
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint ./src ./tests",
@@ -33,10 +34,6 @@
     "test:build": "publint --strict",
     "build": "vite build"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
   "type": "module",
   "types": "dist/esm/index.d.ts",
   "main": "dist/cjs/index.cjs",
@@ -55,10 +52,10 @@
     "./package.json": "./package.json"
   },
   "sideEffects": false,
-  "peerDependencies": {
-    "react": "^17.0.0 || ^18.0.0",
-    "react-dom": "^17.0.0 || ^18.0.0"
-  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "dependencies": {
     "@tanstack/store": "workspace:*",
     "use-sync-external-store": "^1.2.0"
@@ -66,5 +63,9 @@
   "devDependencies": {
     "@types/use-sync-external-store": "^0.0.3",
     "@vitejs/plugin-react": "^4.3.1"
+  },
+  "peerDependencies": {
+    "react": "^17.0.0 || ^18.0.0",
+    "react-dom": "^17.0.0 || ^18.0.0"
   }
 }

--- a/packages/solid-store/package.json
+++ b/packages/solid-store/package.json
@@ -1,23 +1,24 @@
 {
   "name": "@tanstack/solid-store",
-  "author": "Tanner Linsley",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
+  "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/store",
-  "homepage": "https://tanstack.com/",
-  "description": "",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/store.git",
+    "directory": "packages/solid-store"
+  },
+  "homepage": "https://tanstack.com/store",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
   },
   "keywords": [
     "store",
     "solid",
     "typescript"
   ],
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/tannerlinsley"
-  },
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint ./src ./tests",
@@ -33,10 +34,6 @@
     "test:build": "publint --strict",
     "build": "tsc -p tsconfig.build.json"
   },
-  "files": [
-    "dist",
-    "src"
-  ],
   "type": "module",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",
@@ -55,14 +52,18 @@
     "./package.json": "./package.json"
   },
   "sideEffects": false,
-  "peerDependencies": {
-    "solid-js": "^1.6.0"
-  },
+  "files": [
+    "dist",
+    "src"
+  ],
   "dependencies": {
     "@tanstack/store": "workspace:*"
   },
   "devDependencies": {
     "solid-js": "^1.7.8",
     "vite-plugin-solid": "^2.10.2"
+  },
+  "peerDependencies": {
+    "solid-js": "^1.6.0"
   }
 }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -1,11 +1,23 @@
 {
   "name": "@tanstack/store",
-  "author": "Tanner Linsley",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
+  "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/store",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/store.git",
+    "directory": "packages/store"
+  },
   "homepage": "https://tanstack.com/store",
-  "description": "",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "keywords": [
+    "store",
+    "typescript"
+  ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint ./src ./tests",
@@ -20,17 +32,6 @@
     "test:lib:dev": "pnpm run test:lib --watch",
     "test:build": "publint --strict",
     "build": "vite build"
-  },
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
-  "keywords": [
-    "store",
-    "typescript"
-  ],
-  "funding": {
-    "type": "github",
-    "url": "https://github.com/sponsors/tannerlinsley"
   },
   "type": "module",
   "types": "dist/esm/index.d.ts",

--- a/packages/svelte-store/package.json
+++ b/packages/svelte-store/package.json
@@ -1,11 +1,32 @@
 {
   "name": "@tanstack/svelte-store",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
+  "author": "Tanner Linsley",
   "license": "MIT",
   "repository": {
     "type": "git",
     "url": "https://github.com/TanStack/store.git",
     "directory": "packages/svelte-store"
+  },
+  "homepage": "https://tanstack.com/store",
+  "funding": {
+    "type": "github",
+    "url": "https://github.com/sponsors/tannerlinsley"
+  },
+  "keywords": [
+    "store",
+    "typescript",
+    "svelte"
+  ],
+  "scripts": {
+    "clean": "rimraf ./dist && rimraf ./coverage",
+    "test:types": "svelte-check --tsconfig ./tsconfig.json",
+    "test:eslint": "eslint ./src ./tests",
+    "test:lib": "vitest",
+    "test:lib:dev": "pnpm run test:lib --watch",
+    "test:build": "publint --strict",
+    "build": "svelte-package --input ./src --output ./dist"
   },
   "type": "module",
   "types": "dist/index.d.ts",
@@ -19,19 +40,11 @@
     },
     "./package.json": "./package.json"
   },
+  "sideEffects": false,
   "files": [
     "dist",
     "src"
   ],
-  "scripts": {
-    "clean": "rimraf ./dist && rimraf ./coverage",
-    "test:types": "svelte-check --tsconfig ./tsconfig.json",
-    "test:eslint": "eslint ./src ./tests",
-    "test:lib": "vitest",
-    "test:lib:dev": "pnpm run test:lib --watch",
-    "test:build": "publint --strict",
-    "build": "svelte-package --input ./src --output ./dist"
-  },
   "dependencies": {
     "@tanstack/store": "workspace:*"
   },

--- a/packages/vue-store/package.json
+++ b/packages/vue-store/package.json
@@ -1,36 +1,24 @@
 {
   "name": "@tanstack/vue-store",
   "version": "0.5.3",
+  "description": "Framework agnostic type-safe store w/ reactive framework adapters",
   "author": "Tanner Linsley",
   "license": "MIT",
-  "repository": "tanstack/store",
-  "homepage": "https://tanstack.com/",
-  "description": "",
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/TanStack/store.git",
+    "directory": "packages/vue-store"
   },
+  "homepage": "https://tanstack.com/store",
   "funding": {
     "type": "github",
     "url": "https://github.com/sponsors/tannerlinsley"
   },
-  "type": "module",
-  "types": "dist/esm/index.d.ts",
-  "main": "dist/cjs/index.cjs",
-  "module": "dist/esm/index.js",
-  "exports": {
-    ".": {
-      "import": {
-        "types": "./dist/esm/index.d.ts",
-        "default": "./dist/esm/index.js"
-      },
-      "require": {
-        "types": "./dist/cjs/index.d.cts",
-        "default": "./dist/cjs/index.cjs"
-      }
-    },
-    "./package.json": "./package.json"
-  },
-  "sideEffects": false,
+  "keywords": [
+    "store",
+    "typescript",
+    "vue"
+  ],
   "scripts": {
     "clean": "rimraf ./dist && rimraf ./coverage",
     "test:eslint": "eslint ./src ./tests",
@@ -50,6 +38,24 @@
     "test:build": "publint --strict",
     "build": "vite build"
   },
+  "type": "module",
+  "types": "dist/esm/index.d.ts",
+  "main": "dist/cjs/index.cjs",
+  "module": "dist/esm/index.js",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/esm/index.d.ts",
+        "default": "./dist/esm/index.js"
+      },
+      "require": {
+        "types": "./dist/cjs/index.d.cts",
+        "default": "./dist/cjs/index.cjs"
+      }
+    },
+    "./package.json": "./package.json"
+  },
+  "sideEffects": false,
   "files": [
     "dist",
     "src"


### PR DESCRIPTION
- The `"repository"` field is supposed to be an object as described here: https://docs.npmjs.com/cli/v10/configuring-npm/package-json#repository
- `"publishConfig"` was removed as it is unnecessary (npm is the default registry)
- I've also re-arranged the properties for consistency, and added a description from the website
- This fix is required for an exciting change I will work on tomorrow... watch this space!