### PR TITLE
ci: Improve Nx inputs

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -55,7 +55,7 @@
     },
     "test:knip": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
+      "inputs": ["{workspaceRoot}/**/*.!(md)"]
     },
     "test:format": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -7,7 +7,6 @@
   "namedInputs": {
     "sharedGlobals": [
       "{workspaceRoot}/.nvmrc",
-      "{workspaceRoot}/eslint.config.js",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.json"
     ],
@@ -16,10 +15,9 @@
       "{projectRoot}/**/*",
       "!{projectRoot}/**/*.md"
     ],
-    "public": [
+    "production": [
       "default",
-      "{projectRoot}/build",
-      "{projectRoot}/dist",
+      "!{projectRoot}/tests/**/*",
       "!{projectRoot}/eslint.config.js"
     ]
   },
@@ -27,7 +25,7 @@
     "test:lib": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
+      "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/coverage"]
     },
     "test:eslint": {
@@ -35,7 +33,7 @@
       "dependsOn": ["^build"],
       "inputs": [
         "default",
-        "^public",
+        "^production",
         "{workspaceRoot}/eslint.config.js",
         "{projectRoot}/eslint.config.js"
       ]
@@ -43,18 +41,18 @@
     "test:types": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^public"]
+      "inputs": ["default", "^production"]
     },
     "build": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
+      "inputs": ["production", "^production"],
       "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
     },
     "test:build": {
       "cache": true,
       "dependsOn": ["build"],
-      "inputs": ["^public"]
+      "inputs": ["production"]
     },
     "test:knip": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -6,7 +6,6 @@
   "parallel": 5,
   "namedInputs": {
     "sharedGlobals": [
-      "{workspaceRoot}/.nvmrc",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.json"
     ],

--- a/nx.json
+++ b/nx.json
@@ -25,31 +25,36 @@
   },
   "targetDefaults": {
     "test:lib": {
+      "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/coverage"],
-      "cache": true
+      "outputs": ["{projectRoot}/coverage"]
     },
     "test:eslint": {
+      "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
+      "inputs": [
+        "default",
+        "^public",
+        "{workspaceRoot}/eslint.config.js",
+        "{projectRoot}/eslint.config.js"
+      ]
     },
     "test:types": {
+      "cache": true,
       "dependsOn": ["^build"],
-      "inputs": ["default", "^public"],
-      "cache": true
+      "inputs": ["default", "^public"]
     },
     "build": {
+      "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["default", "^public"],
-      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"],
-      "cache": true
+      "outputs": ["{projectRoot}/build", "{projectRoot}/dist"]
     },
     "test:build": {
+      "cache": true,
       "dependsOn": ["build"],
-      "inputs": ["^public"],
-      "cache": true
+      "inputs": ["^public"]
     },
     "test:knip": {
       "cache": true,
@@ -61,7 +66,7 @@
     },
     "test:sherif": {
       "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
+      "inputs": ["{workspaceRoot}/**/package.json"]
     }
   }
 }

--- a/nx.json
+++ b/nx.json
@@ -26,13 +26,13 @@
       "cache": true,
       "inputs": ["{workspaceRoot}/**/*"]
     },
+    "test:knip": {
+      "cache": true,
+      "inputs": ["{workspaceRoot}/**/*"]
+    },
     "test:sherif": {
       "cache": true,
       "inputs": ["{workspaceRoot}/**/package.json"]
-    },
-    "test:knip": {
-      "cache": true,
-      "inputs": ["{workspaceRoot}/**/*.!(md)"]
     },
     "test:eslint": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -30,12 +30,7 @@
     "test:eslint": {
       "cache": true,
       "dependsOn": ["^build"],
-      "inputs": [
-        "default",
-        "^production",
-        "{workspaceRoot}/eslint.config.js",
-        "{projectRoot}/eslint.config.js"
-      ]
+      "inputs": ["default", "^production", "{workspaceRoot}/eslint.config.js"]
     },
     "test:types": {
       "cache": true,

--- a/nx.json
+++ b/nx.json
@@ -6,6 +6,7 @@
   "parallel": 5,
   "namedInputs": {
     "sharedGlobals": [
+      "{workspaceRoot}/.nvmrc",
       "{workspaceRoot}/package.json",
       "{workspaceRoot}/tsconfig.json"
     ],
@@ -21,16 +22,28 @@
     ]
   },
   "targetDefaults": {
-    "test:lib": {
+    "test:format": {
       "cache": true,
-      "dependsOn": ["^build"],
-      "inputs": ["default", "^production"],
-      "outputs": ["{projectRoot}/coverage"]
+      "inputs": ["{workspaceRoot}/**/*"]
+    },
+    "test:sherif": {
+      "cache": true,
+      "inputs": ["{workspaceRoot}/**/package.json"]
+    },
+    "test:knip": {
+      "cache": true,
+      "inputs": ["{workspaceRoot}/**/*.!(md)"]
     },
     "test:eslint": {
       "cache": true,
       "dependsOn": ["^build"],
       "inputs": ["default", "^production", "{workspaceRoot}/eslint.config.js"]
+    },
+    "test:lib": {
+      "cache": true,
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production"],
+      "outputs": ["{projectRoot}/coverage"]
     },
     "test:types": {
       "cache": true,
@@ -47,18 +60,6 @@
       "cache": true,
       "dependsOn": ["build"],
       "inputs": ["production"]
-    },
-    "test:knip": {
-      "cache": true,
-      "inputs": ["{workspaceRoot}/**/*.!(md)"]
-    },
-    "test:format": {
-      "cache": true,
-      "inputs": ["{workspaceRoot}/**/*"]
-    },
-    "test:sherif": {
-      "cache": true,
-      "inputs": ["{workspaceRoot}/**/package.json"]
     }
   }
 }


### PR DESCRIPTION
- Renamed `public` to `production` to match [Nx docs](https://nx.dev/reference/inputs)
- `build` will not be invalidated when only tests change
- `test:build` now has the right cache inputs
- `test:sherif` only depends on `package.json` files