### PR TITLE
feat: add lazyness to derived

### DIFF
--- a/packages/store/src/derived.ts
+++ b/packages/store/src/derived.ts
@@ -8,7 +8,7 @@ interface DerivedOptions<TState> {
    * Should the value of `Derived` only be computed once it is accessed
    * @default false
    */
-  lazy?: boolean;
+  lazy?: boolean
 }
 
 export type Deps = Array<Derived<any> | Store<any>>
@@ -30,7 +30,7 @@ export class Derived<TState> {
     this.deps = deps
     this.options = options
     this.fn = fn
-    const initVal = options?.lazy ? undefined as ReturnType<typeof fn> : fn()
+    const initVal = options?.lazy ? (undefined as ReturnType<typeof fn>) : fn()
     this._store = new Store(initVal, {
       onSubscribe: options?.onSubscribe?.bind(this) as never,
       onUpdate: options?.onUpdate,

--- a/packages/store/src/derived.ts
+++ b/packages/store/src/derived.ts
@@ -4,14 +4,21 @@ import type { Listener } from './types'
 interface DerivedOptions<TState> {
   onSubscribe?: (listener: Listener, derived: Derived<TState>) => () => void
   onUpdate?: () => void
+  /**
+   * Should the value of `Derived` only be computed once it is accessed
+   * @default false
+   */
+  lazy?: boolean;
 }
 
 export type Deps = Array<Derived<any> | Store<any>>
 
 export class Derived<TState> {
-  _store!: Store<TState>
+  _store: Store<TState>
   rootStores = new Set<Store<unknown>>()
   deps: Deps
+  options?: DerivedOptions<TState>
+  fn: () => TState
 
   // Functions representing the subscriptions. Call a function to cleanup
   _subscriptions: Array<() => void> = []
@@ -21,7 +28,10 @@ export class Derived<TState> {
 
   constructor(deps: Deps, fn: () => TState, options?: DerivedOptions<TState>) {
     this.deps = deps
-    this._store = new Store(fn(), {
+    this.options = options
+    this.fn = fn
+    const initVal = options?.lazy ? undefined as ReturnType<typeof fn> : fn()
+    this._store = new Store(initVal, {
       onSubscribe: options?.onSubscribe?.bind(this) as never,
       onUpdate: options?.onUpdate,
     })
@@ -83,7 +93,10 @@ export class Derived<TState> {
           __depsThatHaveWrittenThisTick.length === relatedLinkedDerivedVals.size
         ) {
           // Yay! All deps are resolved - write the value of this derived
-          this._store.setState(fn)
+          if (!options?.lazy) {
+            this._store.setState(fn)
+          }
+
           // Cleanup the deps that have written this tick
           __depsThatHaveWrittenThisTick = []
           this._whatStoreIsCurrentlyInUse = null
@@ -96,6 +109,11 @@ export class Derived<TState> {
   }
 
   get state() {
+    if (this.options?.lazy && this._store.state === undefined) {
+      this.options.lazy = false
+      this._store.setState(() => this.fn())
+      return this._store.state
+    }
     return this._store.state
   }
 

--- a/packages/store/tests/derived.test.ts
+++ b/packages/store/tests/derived.test.ts
@@ -107,13 +107,16 @@ describe('Derived', () => {
     expect(tripleCountFn).toHaveBeenNthCalledWith(2, 90)
   })
 
-
   test('Derive from store and another derived, even when lazy', () => {
     const count = new Store(10)
 
-    const doubleCount = new Derived([count], () => {
-      return count.state * 2
-    }, {lazy: true})
+    const doubleCount = new Derived(
+      [count],
+      () => {
+        return count.state * 2
+      },
+      { lazy: true },
+    )
 
     const tripleCount = new Derived([count, doubleCount], () => {
       return count.state + doubleCount.state
@@ -136,10 +139,14 @@ describe('Derived', () => {
   test("Derive that's lazy should not update on first tick", () => {
     const count = new Store(10)
     const fn = vi.fn()
-    const doubleCount = new Derived([count], () => {
-      fn();
-      return count.state * 2
-    }, { lazy: true })
+    const doubleCount = new Derived(
+      [count],
+      () => {
+        fn()
+        return count.state * 2
+      },
+      { lazy: true },
+    )
 
     const doubleCountFn = viFnSubscribe(doubleCount)
 
@@ -147,5 +154,5 @@ describe('Derived', () => {
 
     expect(doubleCountFn).not.toHaveBeenCalled()
     expect(fn).not.toHaveBeenCalled()
-  });
+  })
 })

--- a/packages/store/tests/derived.test.ts
+++ b/packages/store/tests/derived.test.ts
@@ -106,4 +106,46 @@ describe('Derived', () => {
     expect(doubleCountFn).toHaveBeenNthCalledWith(2, 60)
     expect(tripleCountFn).toHaveBeenNthCalledWith(2, 90)
   })
+
+
+  test('Derive from store and another derived, even when lazy', () => {
+    const count = new Store(10)
+
+    const doubleCount = new Derived([count], () => {
+      return count.state * 2
+    }, {lazy: true})
+
+    const tripleCount = new Derived([count, doubleCount], () => {
+      return count.state + doubleCount.state
+    })
+
+    const doubleCountFn = viFnSubscribe(doubleCount)
+    const tripleCountFn = viFnSubscribe(tripleCount)
+
+    count.setState(() => 20)
+
+    expect(doubleCountFn).toHaveBeenNthCalledWith(1, 40)
+    expect(tripleCountFn).toHaveBeenNthCalledWith(1, 60)
+
+    count.setState(() => 30)
+
+    expect(doubleCountFn).toHaveBeenNthCalledWith(2, 60)
+    expect(tripleCountFn).toHaveBeenNthCalledWith(2, 90)
+  })
+
+  test("Derive that's lazy should not update on first tick", () => {
+    const count = new Store(10)
+    const fn = vi.fn()
+    const doubleCount = new Derived([count], () => {
+      fn();
+      return count.state * 2
+    }, { lazy: true })
+
+    const doubleCountFn = viFnSubscribe(doubleCount)
+
+    count.setState(() => 20)
+
+    expect(doubleCountFn).not.toHaveBeenCalled()
+    expect(fn).not.toHaveBeenCalled()
+  });
 })


### PR DESCRIPTION
> This PR builds on top of #40, please merge that first

This PR adds in a lazyness option to the derived class that:

- Doesn't update a value until it's needed
- Still works when other items are derived from _it_