### PR TITLE
fix(angular): update peerDependencies range

### DIFF
--- a/packages/angular-store/package.json
+++ b/packages/angular-store/package.json
@@ -63,7 +63,7 @@
     "zone.js": "^0.15.0"
   },
   "peerDependencies": {
-    "@angular/common": ">=16 < 18",
-    "@angular/core": ">=16 < 18"
+    "@angular/common": ">=16.0.0",
+    "@angular/core": ">=16.0.0"
   }
 }


### PR DESCRIPTION
Users on Angular 18 currently need to force override peer dependency restriction. This changes the range to match that used by `@tanstack/angular-query-experimental`.