### PR TITLE
Fix typo in quickstart guide

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -25,7 +25,7 @@ This `Store` can then be used to track updates to your data:
 
 ```typescript
 const unsub = countStore.subscribe(() => {
-  console.log('The count is now:', count.state);
+  console.log('The count is now:', countStore.state);
 });
 
 // Later, to cleanup


### PR DESCRIPTION
the state was not read from the correct variable