### PR TITLE
fix(derived auto mount)

### DIFF
--- a/packages/store/tests/derived.bench.ts
+++ b/packages/store/tests/derived.bench.ts
@@ -33,20 +33,20 @@ describe('Derived', () => {
   bench('TanStack', () => {
     const a = new Store(1)
     const b = new Derived({ deps: [a], fn: () => a.state })
-    b.mount()
+    // b.mount() - No longer needed
     const c = new Derived({ deps: [a], fn: () => a.state })
-    c.mount()
+    // c.mount() - No longer needed
     const d = new Derived({ deps: [b], fn: () => b.state })
-    d.mount()
+    // d.mount() - No longer needed
     const e = new Derived({ deps: [b], fn: () => b.state })
-    e.mount()
+    // e.mount() - No longer needed
     const f = new Derived({ deps: [c], fn: () => c.state })
-    f.mount()
+    // f.mount() - No longer needed
     const g = new Derived({
       deps: [d, e, f],
       fn: () => d.state + e.state + f.state,
     })
-    g.mount()
+    // g.mount() - No longer needed
 
     g.subscribe(() => noop(g.state))
 
@@ -114,7 +114,7 @@ describe('Derived', () => {
       () => {
         console.log(g())
       },
-      () => {},
+      () => { },
       false,
     )
 

--- a/packages/store/tests/derived.test.ts
+++ b/packages/store/tests/derived.test.ts
@@ -32,7 +32,7 @@ describe('Derived', () => {
       },
     })
 
-    doubleCount.mount()
+    // doubleCount.mount() - No longer needed
 
     const sumDoubleHalfCount = new Derived({
       deps: [halfCount, doubleCount],
@@ -41,7 +41,7 @@ describe('Derived', () => {
       },
     })
 
-    sumDoubleHalfCount.mount()
+    // sumDoubleHalfCount.mount() - No longer needed
 
     const halfCountFn = viFnSubscribe(halfCount)
     const doubleCountFn = viFnSubscribe(doubleCount)
@@ -117,7 +117,7 @@ describe('Derived', () => {
       },
     })
 
-    doubleCount.mount()
+    // doubleCount.mount() - No longer needed
 
     const tripleCount = new Derived({
       deps: [count, doubleCount],
@@ -126,7 +126,7 @@ describe('Derived', () => {
       },
     })
 
-    tripleCount.mount()
+    // tripleCount.mount() - No longer needed
 
     const doubleCountFn = viFnSubscribe(doubleCount)
     const tripleCountFn = viFnSubscribe(tripleCount)
@@ -150,7 +150,7 @@ describe('Derived', () => {
         return store.state * 2
       },
     })
-    derived.mount()
+    // derived.mount() No longer needed
     const fn = vi.fn()
     derived.subscribe(fn)
     store.setState(() => 24)
@@ -169,7 +169,7 @@ describe('Derived', () => {
         return void 0
       },
     })
-    derived.mount()
+    // derived.mount() - No longer needed
     expect(fn).toBeCalledWith({
       prevDepVals: undefined,
       currDepVals: [12, date],
@@ -187,7 +187,7 @@ describe('Derived', () => {
       deps: [count],
       fn: () => count.state / 2,
     })
-    halfCount.mount()
+    // halfCount.mount() - No longer needed
     const fn = vi.fn()
     const derived = new Derived({
       deps: [count, halfCount],
@@ -196,7 +196,7 @@ describe('Derived', () => {
         return void 0
       },
     })
-    derived.mount()
+    // derived.mount() - No longer needed
     expect(fn).toBeCalledWith({
       prevDepVals: undefined,
       currDepVals: [12, 6],
@@ -220,7 +220,7 @@ describe('Derived', () => {
         return count.state
       },
     })
-    derived.mount()
+    // derived.mount() - No longer needed
     expect(fn).toBeCalledWith(undefined)
     count.setState(() => 24)
     expect(fn).toBeCalledWith(12)
@@ -241,7 +241,7 @@ describe('Derived', () => {
     cleanup2()
     const cleanup3 = derived.mount()
     cleanup3()
-    derived.mount()
+    // derived.mount() - No longer needed
 
     count.setState(() => 24)
 
@@ -260,7 +260,7 @@ describe('Derived', () => {
 
     count.setState(() => 24)
 
-    derived.mount()
+    // derived.mount() - No longer needed
 
     expect(count.state).toBe(24)
     expect(derived.state).toBe(48)
@@ -285,7 +285,7 @@ describe('Derived', () => {
     unmount2()
     const unmount3 = derived.mount()
     unmount3()
-    derived.mount()
+    // derived.mount() - No longer needed
 
     expect(count.state).toBe(24)
     expect(derived.state).toBe(48)
@@ -309,8 +309,8 @@ describe('Derived', () => {
       },
     })
 
-    halfDouble.mount()
-    double.mount()
+    // halfDouble.mount() - No longer needed
+    // double.mount() - No longer needed
 
     count.setState(() => 24)
 
@@ -336,8 +336,8 @@ describe('Derived', () => {
       },
     })
 
-    countPlusDouble.mount()
-    double.mount()
+    // countPlusDouble.mount() - No longer needed
+    // double.mount() - No longer needed
 
     count.setState(() => 24)
 
@@ -367,8 +367,8 @@ describe('Derived', () => {
       },
     })
 
-    halfDouble.mount()
-    double.mount()
+    // halfDouble.mount() - No longer needed
+    // double.mount() - No longer needed
 
     expect(fn).toHaveBeenLastCalledWith(3)
   })


### PR DESCRIPTION
The mount method currently serves three important functions:

- Registering the derived value on the dependency graph (`registerOnGraph`)
- Checking if recalculation is needed deeply (`checkIfRecalculationNeededDeeply`)
- Returning a cleanup function that:
    - Unregisters from the graph
    - Cleans up subscriptions

The challenge is handling these responsibilities without requiring users to explicitly call `mount()`.

The proposed solution

  - The subscribe method now checks if this is the first subscriber and automatically mounts the derived value if needed.
  - When the last listener is removed, it automatically unmounts.
  - The actual mounting logic is moved to private methods (`_mount` and `_unmount)`, while keeping the public mount method for backward compatibility with a deprecation notice.
  - Added` _isMounted` and `_cleanupFn` fields to track the current mounting state and store the cleanup function.
  
 I have also written tests to validate these processes.
 
 
![image](https://github.com/user-attachments/assets/081299ee-d252-42c5-b313-2f500afaa8b0)


it is skipping line 225, for some reason I do not know

