### PR TITLE
feat(svelte): allow dynamic Store instance

### DIFF
--- a/docs/framework/svelte/reference/functions/shallow.md
+++ b/docs/framework/svelte/reference/functions/shallow.md
@@ -11,7 +11,7 @@ title: shallow
 function shallow<T>(objA, objB): boolean
 ```
 
-Defined in: [index.svelte.ts:43](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L43)
+Defined in: [index.svelte.ts:50](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L50)
 
 ## Type Parameters
 

--- a/docs/framework/svelte/reference/functions/usestore.md
+++ b/docs/framework/svelte/reference/functions/usestore.md
@@ -13,7 +13,7 @@ title: useStore
 function useStore<TState, TSelected>(store, selector?): object
 ```
 
-Defined in: [index.svelte.ts:10](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L10)
+Defined in: [index.svelte.ts:12](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L12)
 
 ### Type Parameters
 
@@ -25,7 +25,7 @@ Defined in: [index.svelte.ts:10](https://github.com/TanStack/store/blob/main/pac
 
 #### store
 
-`Store`\<`TState`, `any`\>
+`MaybeGetter`\<`Store`\<`TState`, `any`\>\>
 
 #### selector?
 
@@ -47,7 +47,7 @@ readonly current: TSelected;
 function useStore<TState, TSelected>(store, selector?): object
 ```
 
-Defined in: [index.svelte.ts:14](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L14)
+Defined in: [index.svelte.ts:16](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/index.svelte.ts#L16)
 
 ### Type Parameters
 
@@ -59,7 +59,7 @@ Defined in: [index.svelte.ts:14](https://github.com/TanStack/store/blob/main/pac
 
 #### store
 
-`Derived`\<`TState`, `any`\>
+`MaybeGetter`\<`Derived`\<`TState`, `any`\>\>
 
 #### selector?
 

--- a/packages/svelte-store/src/index.svelte.ts
+++ b/packages/svelte-store/src/index.svelte.ts
@@ -44,9 +44,7 @@ export function useStore<TState, TSelected = NoInfer<TState>>(
 }
 
 function toValue<T>(store: T | (() => T)): T {
-  return typeof store === 'function'
-    ? (store as () => T)()
-    : store
+  return typeof store === 'function' ? (store as () => T)() : store
 }
 
 export function shallow<T>(objA: T, objB: T) {

--- a/packages/svelte-store/tests/DynamicStore.test.svelte
+++ b/packages/svelte-store/tests/DynamicStore.test.svelte
@@ -8,8 +8,11 @@
 
   let store = $state(createStore(0))
 
-  const storeVal = useStore(() => store, (state) => state.count)
+  const storeVal = useStore(
+    () => store,
+    (state) => state.count,
+  )
 </script>
 
 <p>Store: {storeVal.current}</p>
-<button onclick={() => store = createStore(10)}>Update store</button>
+<button onclick={() => (store = createStore(10))}>Update store</button>

--- a/packages/svelte-store/tests/DynamicStore.test.svelte
+++ b/packages/svelte-store/tests/DynamicStore.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { Store } from '@tanstack/store'
+  import { useStore } from '../src/index.svelte.js'
+
+  function createStore(count: number) {
+    return new Store({ count })
+  }
+
+  let store = $state(createStore(0))
+
+  const storeVal = useStore(() => store, (state) => state.count)
+</script>
+
+<p>Store: {storeVal.current}</p>
+<button onclick={() => store = createStore(10)}>Update store</button>

--- a/packages/svelte-store/tests/index.test.ts
+++ b/packages/svelte-store/tests/index.test.ts
@@ -3,6 +3,7 @@ import { render, waitFor } from '@testing-library/svelte'
 import { userEvent } from '@testing-library/user-event'
 import { shallow } from '../src/index.svelte.js'
 import TestBaseStore from './BaseStore.test.svelte'
+import DynamicStore from './DynamicStore.test.svelte'
 import TestRerender from './Render.test.svelte'
 
 const user = userEvent.setup()
@@ -25,6 +26,14 @@ describe('useStore', () => {
 
     await user.click(getByText('Update ignored'))
     expect(getByText('Number rendered: 2')).toBeInTheDocument()
+  })
+
+  it('allows us to use a dynamic store', async () => {
+    const { getByText } = render(DynamicStore)
+    expect(getByText('Store: 0')).toBeInTheDocument()
+
+    await user.click(getByText('Update store'))
+    await waitFor(() => expect(getByText('Store: 10')).toBeInTheDocument())
   })
 })
 


### PR DESCRIPTION
The `useStore()` function needs to be updated to accommodate dynamic `Store` instance values from `@tanstack/db`. See full [discussion](https://discord.com/channels/719702312431386674/1373285617890234400/1373494059548541000).

This PR already reruns the `$effect` callback when the `Store` instance changes but the `.subscribe` callback never gets invoked. Tbh not sure if this is optimal but I don't see an obvious better way of reacting to `@tanstack/db`'s [compiledQuery](https://github.com/TanStack/db/blob/1c318955d7fff533988663863701c95896c3b7ea/packages/react-db/src/useLiveQuery.ts#L29,L34) changes.

cc @crutchcorn 