### PR TITLE
Updated setState to support updateFn to work with both updater function and state

### DIFF
--- a/docs/reference/classes/store.md
+++ b/docs/reference/classes/store.md
@@ -13,8 +13,6 @@ Defined in: [store.ts:28](https://github.com/TanStack/store/blob/main/packages/s
 
 • **TState**
 
-• **TUpdater** *extends* `AnyUpdater` = (`cb`) => `TState`
-
 ## Constructors
 
 ### new Store()

--- a/docs/reference/interfaces/storeoptions.md
+++ b/docs/reference/interfaces/storeoptions.md
@@ -13,8 +13,6 @@ Defined in: [store.ts:5](https://github.com/TanStack/store/blob/main/packages/st
 
 • **TState**
 
-• **TUpdater** *extends* `AnyUpdater` = (`cb`) => `TState`
-
 ## Properties
 
 ### onSubscribe()?

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -8,6 +8,8 @@ export const store = new Store({
   cats: 0,
 })
 
+const countStore = new Store(0);
+
 interface DisplayProps {
   animal: 'dogs' | 'cats'
 }
@@ -16,6 +18,11 @@ interface DisplayProps {
 const Display = ({ animal }: DisplayProps) => {
   const count = useStore(store, (state) => state[animal])
   return <div>{`${animal}: ${count}`}</div>
+}
+
+const DisplayCount = () => {
+  const count = useStore(countStore);
+  return <div>{`count: ${count}`}</div>
 }
 
 const updateState = (animal: 'dogs' | 'cats') => {
@@ -47,6 +54,9 @@ function App() {
       <Display animal="dogs" />
       <Increment animal="cats" />
       <Display animal="cats" />
+      <button onClick={() => countStore.setState((v) => v + 1)}>Update count</button>
+      <button onClick={() => countStore.setState(0)}>Reset count</button>
+      <DisplayCount />
     </div>
   )
 }

--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -8,7 +8,11 @@ export const store = new Store({
   cats: 0,
 })
 
-const countStore = new Store(0);
+const countStore = new Store(1, {
+    updateFn: prevState => updater => {
+        return updater(prevState) + prevState;
+    }
+});
 
 interface DisplayProps {
   animal: 'dogs' | 'cats'
@@ -18,11 +22,6 @@ interface DisplayProps {
 const Display = ({ animal }: DisplayProps) => {
   const count = useStore(store, (state) => state[animal])
   return <div>{`${animal}: ${count}`}</div>
-}
-
-const DisplayCount = () => {
-  const count = useStore(countStore);
-  return <div>{`count: ${count}`}</div>
 }
 
 const updateState = (animal: 'dogs' | 'cats') => {
@@ -42,6 +41,17 @@ const Increment = ({ animal }: IncrementProps) => (
   <button onClick={() => updateState(animal)}>My Friend Likes {animal}</button>
 )
 
+const DisplayCount = () => {
+    const count = useStore(countStore);
+    return (
+        <>
+            <button onClick={() => countStore.setState(1)}>Update count - part1</button>
+            <button onClick={() => countStore.setState(() => 1)}>Update count - part2</button>
+            <div>{`count: ${count}`}</div>
+        </>
+    );
+};
+
 function App() {
   return (
     <div>
@@ -54,8 +64,6 @@ function App() {
       <Display animal="dogs" />
       <Increment animal="cats" />
       <Display animal="cats" />
-      <button onClick={() => countStore.setState((v) => v + 1)}>Update count</button>
-      <button onClick={() => countStore.setState(0)}>Reset count</button>
       <DisplayCount />
     </div>
   )

--- a/packages/angular-store/src/index.ts
+++ b/packages/angular-store/src/index.ts
@@ -17,7 +17,7 @@ export * from '@tanstack/store'
 type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export function injectStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any>,
+  store: Store<TState>,
   selector?: (state: NoInfer<TState>) => TSelected,
   options?: CreateSignalOptions<TSelected> & { injector?: Injector },
 ): Signal<TSelected>
@@ -27,7 +27,7 @@ export function injectStore<TState, TSelected = NoInfer<TState>>(
   options?: CreateSignalOptions<TSelected> & { injector?: Injector },
 ): Signal<TSelected>
 export function injectStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any> | Derived<TState, any>,
+  store: Store<TState> | Derived<TState, any>,
   selector: (state: NoInfer<TState>) => TSelected = (d) => d as TSelected,
   options: CreateSignalOptions<TSelected> & { injector?: Injector } = {
     equal: shallow,

--- a/packages/react-store/src/index.ts
+++ b/packages/react-store/src/index.ts
@@ -9,7 +9,7 @@ export * from '@tanstack/store'
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any>,
+  store: Store<TState>,
   selector?: (state: NoInfer<TState>) => TSelected,
 ): TSelected
 export function useStore<TState, TSelected = NoInfer<TState>>(
@@ -17,7 +17,7 @@ export function useStore<TState, TSelected = NoInfer<TState>>(
   selector?: (state: NoInfer<TState>) => TSelected,
 ): TSelected
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any> | Derived<TState, any>,
+  store: Store<TState> | Derived<TState, any>,
   selector: (state: NoInfer<TState>) => TSelected = (d) => d as any,
 ): TSelected {
   const slice = useSyncExternalStoreWithSelector(

--- a/packages/solid-store/src/index.tsx
+++ b/packages/solid-store/src/index.tsx
@@ -11,7 +11,7 @@ export * from '@tanstack/store'
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any>,
+  store: Store<TState>,
   selector?: (state: NoInfer<TState>) => TSelected,
 ): Accessor<TSelected>
 export function useStore<TState, TSelected = NoInfer<TState>>(
@@ -19,7 +19,7 @@ export function useStore<TState, TSelected = NoInfer<TState>>(
   selector?: (state: NoInfer<TState>) => TSelected,
 ): Accessor<TSelected>
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any> | Derived<TState, any>,
+  store: Store<TState> | Derived<TState, any>,
   selector: (state: NoInfer<TState>) => TSelected = (d) => d as any,
 ): Accessor<TSelected> {
   const [slice, setSlice] = createStore({

--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -1,12 +1,12 @@
 import { __flush } from './scheduler'
 import { isUpdaterFunction } from './types'
-import type { Listener } from './types'
+import type { Listener, Updater, UpdaterFn } from './types'
 
 export interface StoreOptions< TState> {
   /**
    * Replace the default update function with a custom one.
    */
-  updateFn?: (previous: TState) => (updater: (prev: TState) => TState) => TState
+  updateFn?: (previous: TState) => (updater: UpdaterFn<TState>) => TState
   /**
    * Called when a listener subscribes to the store.
    *
@@ -46,7 +46,7 @@ export class Store<TState> {
   /**
    * Update the store state safely with improved type checking
    */
-  setState(updater: TState | ((prevState: TState) => TState)): void {
+  setState(updater: Updater<TState>): void {
     this.prevState = this.state
 
     if (isUpdaterFunction(updater)) {

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -1,7 +1,12 @@
 /**
+ * Type-safe updater function
+ */
+export type UpdaterFn<T> = (prev: T) => T;
+
+/**
  * Type-safe updater that can be either a function or direct value
  */
-export type Updater<T> = ((prev: T) => T) | T
+export type Updater<T> = UpdaterFn<T> | T
 
 /**
  * @private

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -1,9 +1,4 @@
 /**
- * @private
- */
-export type AnyUpdater = (prev: any) => any
-
-/**
  * Type-safe updater that can be either a function or direct value
  */
 export type Updater<T> = ((prev: T) => T) | T

--- a/packages/store/tests/scheduler.test.ts
+++ b/packages/store/tests/scheduler.test.ts
@@ -9,7 +9,7 @@ import {
 
 describe('Scheduler logic', () => {
   test('Should build a graph properly', () => {
-    const count = new Store<any, any>(10)
+    const count = new Store<any>(10)
 
     const halfCount = new Derived<any, any>({
       deps: [count],
@@ -36,7 +36,7 @@ describe('Scheduler logic', () => {
   })
 
   test('should unbuild a graph properly', () => {
-    const count = new Store<any, any>(10)
+    const count = new Store<any>(10)
 
     const halfCount = new Derived<any, any>({
       deps: [count],
@@ -99,7 +99,7 @@ describe('Scheduler logic', () => {
   })
 
   test('should register graph items in the wrong order properly', () => {
-    const count = new Store<any, any>(12)
+    const count = new Store<any>(12)
 
     const double = new Derived<any, any>({
       deps: [count],
@@ -124,7 +124,7 @@ describe('Scheduler logic', () => {
   })
 
   test('should register graph items in the right direction order', () => {
-    const count = new Store<any, any>(12)
+    const count = new Store<any>(12)
 
     const double = new Derived<any, any>({
       deps: [count],

--- a/packages/store/tests/store.test.ts
+++ b/packages/store/tests/store.test.ts
@@ -53,6 +53,24 @@ describe('store', () => {
     expect(typeof store.state).toEqual('number')
   })
 
+  test(`updateFn acts as state transformer when directly updating state`, () => {
+    const store = new Store(1, {
+      updateFn: prevState => updater => {
+        return updater(prevState) + prevState;
+      }
+    })
+
+    store.setState(1)
+
+    expect(store.state).toEqual(2)
+
+    store.setState(1)
+
+    expect(store.state).toEqual(3)
+
+    expect(typeof store.state).toEqual('number')
+  })
+
   test('listeners should receive old and new values', () => {
     const store = new Store(12)
     const fn = vi.fn()

--- a/packages/svelte-store/src/index.svelte.ts
+++ b/packages/svelte-store/src/index.svelte.ts
@@ -8,7 +8,7 @@ export * from '@tanstack/store'
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any>,
+  store: Store<TState>,
   selector?: (state: NoInfer<TState>) => TSelected,
 ): { readonly current: TSelected }
 export function useStore<TState, TSelected = NoInfer<TState>>(
@@ -16,7 +16,7 @@ export function useStore<TState, TSelected = NoInfer<TState>>(
   selector?: (state: NoInfer<TState>) => TSelected,
 ): { readonly current: TSelected }
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any> | Derived<TState, any>,
+  store: Store<TState> | Derived<TState, any>,
   selector: (state: NoInfer<TState>) => TSelected = (d) => d as any,
 ): { readonly current: TSelected } {
   let slice = $state(selector(store.state))

--- a/packages/vue-store/src/index.ts
+++ b/packages/vue-store/src/index.ts
@@ -10,7 +10,7 @@ export * from '@tanstack/store'
 export type NoInfer<T> = [T][T extends any ? 0 : never]
 
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any>,
+  store: Store<TState>,
   selector?: (state: NoInfer<TState>) => TSelected,
 ): Readonly<Ref<TSelected>>
 export function useStore<TState, TSelected = NoInfer<TState>>(
@@ -18,7 +18,7 @@ export function useStore<TState, TSelected = NoInfer<TState>>(
   selector?: (state: NoInfer<TState>) => TSelected,
 ): Readonly<Ref<TSelected>>
 export function useStore<TState, TSelected = NoInfer<TState>>(
-  store: Store<TState, any> | Derived<TState, any>,
+  store: Store<TState> | Derived<TState, any>,
   selector: (state: NoInfer<TState>) => TSelected = (d) => d as any,
 ): Readonly<Ref<TSelected>> {
   const slice = ref(selector(store.state)) as Ref<TSelected>


### PR DESCRIPTION
Currently `updateFn` is throwing an error when trying to setState directly without using function. e.g.
```
const countStore = new Store(1, {
    updateFn: prevState => updater => {
        return updater(prevState) + prevState;
    }
});
countStore.setState(1) // error
countStore.setState(() => 1) // success
```
Updated setState to support that. Also we should not allow user to update Updater type so, remove `TUpdater`.