### PR TITLE
Have example reference the store type to keep types aligned

### DIFF
--- a/examples/react/simple/src/index.tsx
+++ b/examples/react/simple/src/index.tsx
@@ -8,17 +8,15 @@ export const store = new Store({
   cats: 0,
 })
 
-interface DisplayProps {
-  animal: 'dogs' | 'cats'
-}
+type Animal = keyof typeof store.state
 
 // This will only re-render when `state[animal]` changes. If an unrelated store property changes, it won't re-render
-const Display = ({ animal }: DisplayProps) => {
+const Display = ({ animal }: { animal: Animal }) => {
   const count = useStore(store, (state) => state[animal])
   return <div>{`${animal}: ${count}`}</div>
 }
 
-const updateState = (animal: 'dogs' | 'cats') => {
+const updateState = (animal: Animal) => {
   store.setState((state) => {
     return {
       ...state,
@@ -27,11 +25,7 @@ const updateState = (animal: 'dogs' | 'cats') => {
   })
 }
 
-interface IncrementProps {
-  animal: 'dogs' | 'cats'
-}
-
-const Increment = ({ animal }: IncrementProps) => (
+const Increment = ({ animal }: { animal: Animal }) => (
   <button onClick={() => updateState(animal)}>My Friend Likes {animal}</button>
 )
 


### PR DESCRIPTION
One of the big draws of the Tanstack ecosystem is the focus on first-class support for type safety. Not having to manually specify types for the store is a big draw.

Having an example that had all the types manually declared undersells that capabilities of the tool.

This PR does a quick edit to the example to demo how the inferred types from the store can be propagated to store updaters and consumers.