### PR TITLE
fix(core): prevent setState crashing when used directly

### DIFF
--- a/packages/store/src/store.ts
+++ b/packages/store/src/store.ts
@@ -38,6 +38,8 @@ export class Store<
     this.prevState = initialState
     this.state = initialState
     this.options = options
+
+    this.setState = this.setState.bind(this);
   }
 
   subscribe = (listener: Listener<TState>) => {

--- a/packages/store/tests/store.test.ts
+++ b/packages/store/tests/store.test.ts
@@ -37,6 +37,16 @@ describe('store', () => {
     expect(store.state).toEqual(4)
   })
 
+  test(`setState works when not directly called on the store`, () => {
+    const store = new Store(5);
+
+    const setState = store.setState
+
+    setState((v) => v + 1)
+
+    expect(store.state).toEqual(6)
+  })
+
   test(`updateFn acts as state transformer`, () => {
     const store = new Store(1, {
       updateFn: (v) => (updater) => Number(updater(v)),


### PR DESCRIPTION
# Overview
This fix resolves a bug introduced in [06c8227](https://github.com/TanStack/store/commit/06c82276f7d0b7d28ece9c375953c1612c3d3257) which converted `setState` from an arrow function to a standard function. The change meant that the `this` context was no longer bound to the store, and would cause the function to crash when called directly `const setState = store.setState`.

Since this change was necessary for function definition overloading in typescript, This PR bounds the function to the store in the constructor and adds test cases for this scenario