### PR TITLE
Handle string and symbol keys in `shallow` object comparison

### DIFF
--- a/packages/react-store/src/index.ts
+++ b/packages/react-store/src/index.ts
@@ -66,8 +66,8 @@ export function shallow<T>(objA: T, objB: T) {
     return true
   }
 
-  const keysA = Reflect.ownKeys(objA)
-  if (keysA.length !== Reflect.ownKeys(objB).length) {
+  const keysA = getOwnKeys(objA)
+  if (keysA.length !== getOwnKeys(objB).length) {
     return false
   }
 
@@ -80,4 +80,10 @@ export function shallow<T>(objA: T, objB: T) {
     }
   }
   return true
+}
+
+function getOwnKeys(obj: object): Array<string | symbol> {
+  return (Object.keys(obj) as Array<string | symbol>).concat(
+    Object.getOwnPropertySymbols(obj),
+  )
 }

--- a/packages/react-store/tests/index.test.tsx
+++ b/packages/react-store/tests/index.test.tsx
@@ -178,6 +178,23 @@ describe('shallow', () => {
     expect(shallow(objA, objB)).toBe(false)
   })
 
+  test('should return true for non-enumerable keys', () => {
+    const objA = {}
+    const objB = {}
+
+    Object.defineProperty(objA, 'a', {
+      enumerable: false,
+      value: 1,
+    })
+
+    Object.defineProperty(objB, 'a', {
+      enumerable: false,
+      value: 2,
+    })
+
+    expect(shallow(objA, objB)).toBe(true)
+  })
+
   test('should return true for shallowly equal maps', () => {
     const objA = new Map([['1', 'hello']])
     const objB = new Map([['1', 'hello']])


### PR DESCRIPTION
Fixes #226

Ensures that objects that contain symbol keys compare those symbol keys in addition to the string keys.