### PR TITLE
refactor(store): scheduler __notifyListeners performance

### DIFF
--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -11,7 +11,7 @@ title: batch
 function batch(fn): void
 ```
 
-Defined in: [scheduler.ts:140](https://github.com/TanStack/store/blob/main/packages/store/src/scheduler.ts#L140)
+Defined in: [scheduler.ts:142](https://github.com/TanStack/store/blob/main/packages/store/src/scheduler.ts#L142)
 
 ## Parameters
 

--- a/packages/store/src/scheduler.ts
+++ b/packages/store/src/scheduler.ts
@@ -65,21 +65,23 @@ function __flush_internals(relatedVals: Set<Derived<unknown>>) {
 }
 
 function __notifyListeners(store: Store<unknown>) {
-  store.listeners.forEach((listener) =>
-    listener({
+  const value = {
       prevVal: store.prevState as never,
       currentVal: store.state as never,
-    }),
-  )
+    }
+  for (const listener of store.listeners) {
+    listener(value)
+  }
 }
 
 function __notifyDerivedListeners(derived: Derived<unknown>) {
-  derived.listeners.forEach((listener) =>
-    listener({
+  const value = {
       prevVal: derived.prevState as never,
       currentVal: derived.state as never,
-    }),
-  )
+    }
+  for (const listener of derived.listeners) {
+    listener(value)
+  }
 }
 
 /**

--- a/packages/store/src/scheduler.ts
+++ b/packages/store/src/scheduler.ts
@@ -66,9 +66,9 @@ function __flush_internals(relatedVals: Set<Derived<unknown>>) {
 
 function __notifyListeners(store: Store<unknown>) {
   const value = {
-      prevVal: store.prevState as never,
-      currentVal: store.state as never,
-    }
+    prevVal: store.prevState as never,
+    currentVal: store.state as never,
+  }
   for (const listener of store.listeners) {
     listener(value)
   }
@@ -76,9 +76,9 @@ function __notifyListeners(store: Store<unknown>) {
 
 function __notifyDerivedListeners(derived: Derived<unknown>) {
   const value = {
-      prevVal: derived.prevState as never,
-      currentVal: derived.state as never,
-    }
+    prevVal: derived.prevState as never,
+    currentVal: derived.state as never,
+  }
   for (const listener of derived.listeners) {
     listener(value)
   }

--- a/packages/store/src/types.ts
+++ b/packages/store/src/types.ts
@@ -12,8 +12,8 @@ export type Updater<T> = ((prev: T) => T) | T
  * @private
  */
 export interface ListenerValue<T> {
-  prevVal: T
-  currentVal: T
+  readonly prevVal: T
+  readonly currentVal: T
 }
 
 /**


### PR DESCRIPTION
If we're ok w/ sending the exact same object to all listeners, instead of 1 new object per listener, we can get much better performance out of the `__notifyListeners` and `__notifyDerivedListeners` methods.

To reflect that it's now a single object, the `ListenerValue` is also updated to be `readonly` to indicate that it should not be mutated by the client.

These functions are already lightweight, but they're also in the hot-path (called a lot when a lot of things are happening) so any gain should be considered in my opinion.

---

Benchmark (tl;dr 3x)

```ts
describe('Scheduler notifyListeners', () => {
  const store: Store<unknown> = {
    listeners: new Set(Array.from({ length: 100 }, () => () => { })),
    prevState: {},
    state: {},
  }

  bench('old', () => {
    __notifyListenersOld(store)
  })

  bench('new', () => {
    __notifyListeners(store)
  })
})
```

```sh
 ✓  @tanstack/store  tests/scheduler.bench.ts > Scheduler notifyListeners 2161ms
     name            hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · old   1,967,110.75  0.0003  1.5716  0.0005  0.0005  0.0007  0.0007  0.0008  ±0.62%   983556
   · new   6,163,908.08  0.0001  0.0201  0.0002  0.0002  0.0002  0.0002  0.0003  ±0.05%  3081955

   @tanstack/store  new - tests/scheduler.bench.ts > Scheduler notifyListeners
    3.13x faster than old
```

---

Most of the performance improvement comes from changing the iteration method from `.forEach()` to `for ... of`. This is usually more performant so here's a benchmark to demonstrate (below). But creating fewer objects (creating the `value` only once) is also a good practice as it saves on RAM in the short term, and avoids the CPU work by the garbage collector later (see https://github.com/TanStack/store/pull/235 for a demonstration of this).

```ts
describe('Scheduler notifyListeners', () => {
  const listeners = new Set(Array.from({ length: 100 }, () => () => { }))
  const value = {}

  bench('forEach', () => {
    listeners.forEach((listener) => listener(value))
  })

  bench('for-of', () => {
    for (const listener of listeners) {
      listener(value)
    }
  })
})
```

```sh
 ✓  @tanstack/store  tests/scheduler.bench.ts > Scheduler notifyListeners 2182ms
     name               hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · forEach  2,014,691.23  0.0004  0.0268  0.0005  0.0005  0.0007  0.0007  0.0007  ±0.04%  1007346
   · for-of   6,344,114.76  0.0001  0.5620  0.0002  0.0002  0.0002  0.0002  0.0003  ±0.31%  3172058

 BENCH  Summary

   @tanstack/store  for-of - tests/scheduler.bench.ts > Scheduler notifyListeners
    3.15x faster than forEach
```