### PR TITLE
refactor(store): scheduler batch finalization performance

### DIFF
--- a/packages/store/src/scheduler.ts
+++ b/packages/store/src/scheduler.ts
@@ -144,7 +144,7 @@ export function batch(fn: () => void) {
   } finally {
     __batchDepth--
     if (__batchDepth === 0) {
-      const pendingUpdateToFlush = Array.from(__pendingUpdates)[0] as
+      const pendingUpdateToFlush = __pendingUpdates.entries().next().value as
         | Store<unknown>
         | undefined
       if (pendingUpdateToFlush) {

--- a/packages/store/src/scheduler.ts
+++ b/packages/store/src/scheduler.ts
@@ -144,9 +144,7 @@ export function batch(fn: () => void) {
   } finally {
     __batchDepth--
     if (__batchDepth === 0) {
-      const pendingUpdateToFlush = __pendingUpdates.entries().next().value as
-        | Store<unknown>
-        | undefined
+      const pendingUpdateToFlush = __pendingUpdates.values().next().value
       if (pendingUpdateToFlush) {
         __flush(pendingUpdateToFlush) // Trigger flush of all pending updates
       }


### PR DESCRIPTION
This is a very minor change, but it's more performant to access the 1st item of a set going through its iterator methods than by deriving an array from it and then reading the 1st value. (Plus as a bonus, types are correct and we don't need the `as` anymore)

---

benchmark (tl;dr 1.3x)

```ts
describe('First of set', () => {
  const set = new Set([1, 2, 3, 4, 5])

  bench('old: Array.from(set)[0]', () => {
    const first = Array.from(set)[0]
  })

  bench('new: set.values().next().value', () => {
    const first = set.values().next().value
  })
})
```

```sh
 ✓  @tanstack/store  tests/scheduler.bench.ts > First of set 10142ms
     name                                       hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · old: Array.from(set)[0]         34,766,506.82  0.0000  0.0557  0.0000  0.0000  0.0000  0.0001  0.0001  ±0.07%  17383254
   · new: set.values().next().value  47,885,284.85  0.0000  0.0256  0.0000  0.0000  0.0000  0.0000  0.0000  ±0.05%  23942643

   @tanstack/store  new: set.values().next().value - tests/scheduler.bench.ts > First of set
    1.38x faster than old: Array.from(set)[0]
```