### PR TITLE
refactor(store): derived getDepVals array init performance

### DIFF
--- a/packages/store/src/derived.ts
+++ b/packages/store/src/derived.ts
@@ -77,8 +77,9 @@ export class Derived<
 
   lastSeenDepValues: Array<unknown> = []
   getDepVals = () => {
-    const prevDepVals = [] as Array<unknown>
-    const currDepVals = [] as Array<unknown>
+    const l = this.options.deps.length
+    const prevDepVals = new Array<unknown>(l)
+    const currDepVals = new Array<unknown>(l)
     for (const dep of this.options.deps) {
       prevDepVals.push(dep.prevState)
       currDepVals.push(dep.state)


### PR DESCRIPTION
When the array length is known in advance, it is more performance to initialize the array to the proper length from the start.

Since `getDepVals` is called on every (?) store change, recursively for all impacted derived stores, performance is probably important.

---

benchmark (tl;dr 1.3x)

```ts
describe('Array push', () => {
  const deps = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]

  bench('old: init empty', () => {
    const vals = []
    for (const dep of deps) {
      vals.push(dep)
    }
  })

  bench('new: init with length', () => {
    const vals = new Array(deps.length)
    for (let i = 0; i < deps.length; i++) {
      vals[i] = deps[i]
    }
  })
})
```

```sh
 ✓  @tanstack/store  tests/derived2.bench.ts > Array push 9169ms
     name                              hz     min     max    mean     p75     p99    p995    p999     rme   samples
   · old: init empty        31,866,406.34  0.0000  4.5047  0.0000  0.0000  0.0000  0.0000  0.0002  ±1.77%  15933204
   · new: init with length  41,778,135.92  0.0000  0.1221  0.0000  0.0000  0.0000  0.0000  0.0001  ±0.08%  20889068

 BENCH  Summary

   @tanstack/store  new: init with length - tests/derived2.bench.ts > Array push
    1.31x faster than old: init empty
```