### PR TITLE
fix (docs): API Reference URLs

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -88,23 +88,23 @@
         },
         {
           "label": "Classes / Store",
-          "to": "reference/classes/store"
+          "to": "reference/classes/Store"
         },
         {
           "label": "Classes / Derived",
-          "to": "reference/classes/derived"
+          "to": "reference/classes/Derived"
         },
         {
           "label": "Classes / Effect",
-          "to": "reference/classes/effect"
+          "to": "reference/classes/Effect"
         },
         {
           "label": "Interfaces / StoreOptions",
-          "to": "reference/interfaces/storeoptions"
+          "to": "reference/interfaces/StoreOptions"
         },
         {
           "label": "Interfaces / DerivedOptions",
-          "to": "reference/interfaces/derivedoptions"
+          "to": "reference/interfaces/DerivedOptions"
         }
       ],
       "frameworks": [


### PR DESCRIPTION
## 🎯 Changes

Some links under the API reference heading in the TanStack Store documentation were not working. These have been fixed.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [X] This change is docs/CI/dev-only (no release).
