### PR TITLE
Support input signals in Angular adapter

### DIFF
--- a/.changeset/eight-ways-dig.md
+++ b/.changeset/eight-ways-dig.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/angular-store': patch
+---
+
+support input signals in angular store

--- a/docs/framework/angular/reference/functions/injectAtom.md
+++ b/docs/framework/angular/reference/functions/injectAtom.md
@@ -9,7 +9,7 @@ title: injectAtom
 function injectAtom<TValue>(atom, options?): WritableAtomSignal<TValue>;
 ```
 
-Defined in: [packages/angular-store/src/injectAtom.ts:44](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectAtom.ts#L44)
+Defined in: [packages/angular-store/src/injectAtom.ts:59](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectAtom.ts#L59)
 
 Returns a [WritableAtomSignal](../interfaces/WritableAtomSignal.md) that reads the current atom value when
 called and exposes a `.set` method for updates.
@@ -27,7 +27,7 @@ atom.
 
 ### atom
 
-`Atom`\<`TValue`\>
+`Atom`\<`TValue`\> | () => `Atom`\<`TValue`\>
 
 ### options?
 

--- a/docs/framework/angular/reference/functions/injectSelector.md
+++ b/docs/framework/angular/reference/functions/injectSelector.md
@@ -12,7 +12,7 @@ function injectSelector<TState, TSelected>(
 options?): Signal<TSelected>;
 ```
 
-Defined in: [packages/angular-store/src/injectSelector.ts:93](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectSelector.ts#L93)
+Defined in: [packages/angular-store/src/injectSelector.ts:55](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectSelector.ts#L55)
 
 Selects a slice of state from an atom or store and returns it as an Angular
 signal.
@@ -33,7 +33,7 @@ This is the primary Angular read hook for TanStack Store.
 
 ### source
 
-[`SelectionSource`](../type-aliases/SelectionSource.md)\<`TState`\>
+[`SelectionSource`](../type-aliases/SelectionSource.md)\<`TState`\> | () => [`SelectionSource`](../type-aliases/SelectionSource.md)\<`TState`\>
 
 ### selector
 

--- a/docs/framework/angular/reference/functions/injectStore.md
+++ b/docs/framework/angular/reference/functions/injectStore.md
@@ -9,16 +9,16 @@ title: _injectStore
 function _injectStore<TState, TActions, TSelected>(
    store, 
    selector, 
-   options?): [Signal<TSelected>, [TActions] extends [never] ? (updater) => void : TActions];
+options?): WritableStoreSliceSignal<TState, TSelected, TActions>;
 ```
 
-Defined in: [packages/angular-store/src/\_injectStore.ts:24](https://github.com/TanStack/store/blob/main/packages/angular-store/src/_injectStore.ts#L24)
+Defined in: [packages/angular-store/src/\_injectStore.ts:34](https://github.com/TanStack/store/blob/main/packages/angular-store/src/_injectStore.ts#L34)
 
 Experimental combined read+write injection function for stores, mirroring
 injectAtom's pattern.
 
-Returns `[signal, actions]` when the store has an actions factory, or
-`[signal, setState]` for plain stores.
+Returns a callable slice with methods when the store has an actions factory, or
+with only the setState method for plain stores.
 
 ## Type Parameters
 
@@ -38,7 +38,7 @@ Returns `[signal, actions]` when the store has an actions factory, or
 
 ### store
 
-`Store`\<`TState`, `TActions`\>
+`Store`\<`TState`, `TActions`\> | () => `Store`\<`TState`, `TActions`\>
 
 ### selector
 
@@ -50,16 +50,16 @@ Returns `[signal, actions]` when the store has an actions factory, or
 
 ## Returns
 
-\[`Signal`\<`TSelected`\>, \[`TActions`\] *extends* \[`never`\] ? (`updater`) => `void` : `TActions`\]
+`WritableStoreSliceSignal`\<`TState`, `TSelected`, `TActions`\>
 
 ## Example
 
 ```ts
 // Store with actions
-readonly result = _injectStore(petStore, (s) => s.cats)
-// result[0] is Signal<number>, result[1] is actions
+readonly dogs = _injectStore(petStore, (s) => s.dogs)
+// dogs() and dogs.addDog()
 
 // Store without actions
-readonly result = _injectStore(plainStore, (s) => s)
-// result[0] is Signal<number>, result[1] is setState
+readonly value = _injectStore(plainStore, (s) => s)
+// value() and value.setState(...)
 ```

--- a/examples/angular/store-actions/src/app/app.component.ts
+++ b/examples/angular/store-actions/src/app/app.component.ts
@@ -46,7 +46,7 @@ const petStore = createStore(
       </div>
       <div>
         <p>Dogs: {{ dogs() }}</p>
-        <button type="button" (click)="dogActions.addDog()">
+        <button type="button" (click)="dogs.addDog()">
           Vote for dogs
         </button>
       </div>
@@ -59,10 +59,8 @@ export class AppComponent {
   cats = injectSelector(petStore, (state) => state.cats)
   addCat = petStore.actions.addCat
 
-  // _injectStore gives both the selected signal and actions in a single tuple
-  private dogResult = _injectStore(petStore, (state) => state.dogs)
-  dogs = this.dogResult[0]
-  dogActions = this.dogResult[1]
+  // _injectStore: callable slice for reads; action methods for writes
+  dogs = _injectStore(petStore, (state) => state.dogs)
 
   total = injectSelector(petStore, (state) => state.cats + state.dogs)
 

--- a/packages/angular-store/package.json
+++ b/packages/angular-store/package.json
@@ -50,11 +50,13 @@
   },
   "devDependencies": {
     "@analogjs/vite-plugin-angular": "^2.4.5",
+    "@analogjs/vitest-angular": "^2.3.1",
     "@angular/common": "^21.2.8",
     "@angular/compiler": "^21.2.8",
     "@angular/core": "^21.2.8",
     "@angular/platform-browser": "^21.2.8",
-    "@angular/platform-browser-dynamic": "^21.2.8",
+    "@testing-library/angular": "^19.1.1",
+    "@testing-library/jest-dom": "^6.9.1",
     "zone.js": "^0.16.1"
   },
   "peerDependencies": {

--- a/packages/angular-store/src/_injectStore.ts
+++ b/packages/angular-store/src/_injectStore.ts
@@ -1,24 +1,34 @@
+import { untracked } from '@angular/core'
 import { injectSelector } from './injectSelector'
 import type { Signal } from '@angular/core'
 import type { Store, StoreActionMap } from '@tanstack/store'
 import type { InjectSelectorOptions } from './injectSelector'
 
+type WritableStoreSliceSignal<
+  TState,
+  TSelected,
+  TActions extends StoreActionMap,
+> = Signal<TSelected> &
+  ([TActions] extends [never]
+    ? Pick<Store<TState>, 'setState'>
+    : TActions)
+
 /**
  * Experimental combined read+write injection function for stores, mirroring
  * injectAtom's pattern.
- *
- * Returns `[signal, actions]` when the store has an actions factory, or
- * `[signal, setState]` for plain stores.
+ * 
+ * Returns a callable slice with methods when the store has an actions factory, or
+ * with only the setState method for plain stores.
  *
  * @example
  * ```ts
  * // Store with actions
- * readonly result = _injectStore(petStore, (s) => s.cats)
- * // result[0] is Signal<number>, result[1] is actions
+ * readonly dogs = _injectStore(petStore, (s) => s.dogs)
+ * // dogs() and dogs.addDog()
  *
  * // Store without actions
- * readonly result = _injectStore(plainStore, (s) => s)
- * // result[0] is Signal<number>, result[1] is setState
+ * readonly value = _injectStore(plainStore, (s) => s)
+ * // value() and value.setState(...)
  * ```
  */
 export function _injectStore<
@@ -26,16 +36,31 @@ export function _injectStore<
   TActions extends StoreActionMap,
   TSelected = NoInfer<TState>,
 >(
-  store: Store<TState, TActions>,
+  store: Store<TState, TActions> | (() => Store<TState, TActions>),
   selector: (state: NoInfer<TState>) => TSelected,
   options?: InjectSelectorOptions<TSelected>,
-): [
-  Signal<TSelected>,
-  [TActions] extends [never] ? Store<TState>['setState'] : TActions,
-] {
+): WritableStoreSliceSignal<TState, TSelected, TActions> {
   const selected = injectSelector(store, selector, options)
-  const actionsOrSetState =
-    (store.actions as StoreActionMap | undefined) ?? store.setState
 
-  return [selected, actionsOrSetState] as any
+  return new Proxy(selected, {
+    apply: () => selected(),
+    get(_target, prop, receiver) {
+      const inst = untracked(() =>
+        typeof store === 'function' ? store() : store,
+      )
+
+      const actions = inst.actions as StoreActionMap | undefined
+
+      if (actions != null && typeof actions === 'object') {
+        const method = Reflect.get(actions, prop, actions)
+        if (Object.hasOwn(actions, prop) && typeof method === 'function') {
+          return method
+        }
+      } else if (prop === 'setState' && typeof inst.setState === 'function') {
+        return inst.setState
+      }
+
+      return Reflect.get(selected, prop, receiver)
+    },
+  }) as WritableStoreSliceSignal<TState, TSelected, TActions>
 }

--- a/packages/angular-store/src/injectAtom.ts
+++ b/packages/angular-store/src/injectAtom.ts
@@ -25,6 +25,21 @@ export interface WritableAtomSignal<T> {
   set: Atom<T>['set']
 }
 
+
+function createSetter<TValue>(
+  atom: Atom<TValue> | (() => Atom<TValue>),
+): Atom<TValue>['set'] {
+  function set(value: TValue): void
+  function set(fn: (prevVal: TValue) => TValue): void
+  function set(
+    updaterOrValue: TValue | ((prevVal: TValue) => TValue),
+  ): void {
+    const _atom = typeof atom === "function" ? atom() : atom
+    _atom.set(updaterOrValue as never)
+  }
+  return set as Atom<TValue>['set']
+}
+
 /**
  * Returns a {@link WritableAtomSignal} that reads the current atom value when
  * called and exposes a `.set` method for updates.
@@ -42,11 +57,11 @@ export interface WritableAtomSignal<T> {
  * ```
  */
 export function injectAtom<TValue>(
-  atom: Atom<TValue>,
+  atom: Atom<TValue> | (() => Atom<TValue>),
   options?: InjectSelectorOptions<TValue>,
 ): WritableAtomSignal<TValue> {
   const value = injectSelector(atom, undefined, options)
   const atomSignal = (() => value()) as WritableAtomSignal<TValue>
-  atomSignal.set = atom.set
+  atomSignal.set = createSetter(atom)
   return atomSignal
 }

--- a/packages/angular-store/src/injectAtom.ts
+++ b/packages/angular-store/src/injectAtom.ts
@@ -1,6 +1,7 @@
 import { injectSelector } from './injectSelector'
 import type { Atom } from '@tanstack/store'
 import type { InjectSelectorOptions } from './injectSelector'
+import type { Signal } from '@angular/core'
 
 /**
  * A callable signal that reads the current atom value when invoked and
@@ -18,26 +19,9 @@ import type { InjectSelectorOptions } from './injectSelector'
  * //                   this.count.set(prev => prev + 1)
  * ```
  */
-export interface WritableAtomSignal<T> {
-  /** Read the current value. */
-  (): T
+export interface WritableAtomSignal<T> extends Signal<T> {
   /** Set the atom value (accepts a direct value or an updater function). */
   set: Atom<T>['set']
-}
-
-
-function createSetter<TValue>(
-  atom: Atom<TValue> | (() => Atom<TValue>),
-): Atom<TValue>['set'] {
-  function set(value: TValue): void
-  function set(fn: (prevVal: TValue) => TValue): void
-  function set(
-    updaterOrValue: TValue | ((prevVal: TValue) => TValue),
-  ): void {
-    const _atom = typeof atom === "function" ? atom() : atom
-    _atom.set(updaterOrValue as never)
-  }
-  return set as Atom<TValue>['set']
 }
 
 /**
@@ -60,8 +44,14 @@ export function injectAtom<TValue>(
   atom: Atom<TValue> | (() => Atom<TValue>),
   options?: InjectSelectorOptions<TValue>,
 ): WritableAtomSignal<TValue> {
-  const value = injectSelector(atom, undefined, options)
-  const atomSignal = (() => value()) as WritableAtomSignal<TValue>
-  atomSignal.set = createSetter(atom)
-  return atomSignal
+  // In the future, this could be updated to use a linkedSignal setter
+  // https://github.com/angular/angular/pull/68708
+  const value = injectSelector(atom, undefined, options) as WritableAtomSignal<TValue>
+  value.set = (
+    updaterOrValue: TValue | ((prevVal: TValue) => TValue),
+  ): void => {
+    const _atom = typeof atom === "function" ? atom() : atom
+    _atom.set(updaterOrValue as never)
+  }
+  return value
 }

--- a/packages/angular-store/src/injectSelector.ts
+++ b/packages/angular-store/src/injectSelector.ts
@@ -70,11 +70,11 @@ export function injectSelector<TState, TSelected = NoInfer<TState>>(
       equal: options?.compare,
     })
 
-    effect(() => {
+    effect((onCleanup) => {
       const { unsubscribe } = _source().subscribe((state) => {
         slice.set(selector(state))
       })
-      return unsubscribe
+      onCleanup(unsubscribe)
     })
 
     return slice.asReadonly()

--- a/packages/angular-store/src/injectSelector.ts
+++ b/packages/angular-store/src/injectSelector.ts
@@ -1,7 +1,7 @@
 import {
-  DestroyRef,
   Injector,
   assertInInjectionContext,
+  effect,
   inject,
   linkedSignal,
   runInInjectionContext,
@@ -23,10 +23,6 @@ export type SelectionSource<T> = {
   }
 }
 
-function defaultCompare<T>(a: T, b: T) {
-  return a === b
-}
-
 function resolveInjector(
   fn: (...args: Array<never>) => unknown,
   injector?: Injector,
@@ -39,40 +35,6 @@ function resolveInjector(
   return injector
 }
 
-function createReadonlySelectionSignal<TSource, TSelected>(
-  source: SelectionSource<TSource>,
-  selector: (state: NoInfer<TSource>) => TSelected,
-  options?: InjectSelectorOptions<TSelected>,
-): Signal<TSelected> {
-  const injector = resolveInjector(
-    createReadonlySelectionSignal,
-    options?.injector,
-  )
-
-  return runInInjectionContext(injector, () => {
-    const destroyRef = inject(DestroyRef)
-    const compare = options?.compare ?? defaultCompare
-    const {
-      injector: _injector,
-      compare: _compare,
-      ...signalOptions
-    } = options ?? {}
-    const slice = linkedSignal(() => selector(source.get()), {
-      ...signalOptions,
-      equal: compare,
-    })
-
-    const { unsubscribe } = source.subscribe((state) => {
-      slice.set(selector(state))
-    })
-
-    destroyRef.onDestroy(() => {
-      unsubscribe()
-    })
-
-    return slice.asReadonly()
-  })
-}
 
 /**
  * Selects a slice of state from an atom or store and returns it as an Angular
@@ -91,10 +53,30 @@ function createReadonlySelectionSignal<TSource, TSelected>(
  * ```
  */
 export function injectSelector<TState, TSelected = NoInfer<TState>>(
-  source: SelectionSource<TState>,
+  source: SelectionSource<TState> | (() => SelectionSource<TState>),
   selector: (state: NoInfer<TState>) => TSelected = (d) =>
     d as unknown as TSelected,
   options?: InjectSelectorOptions<TSelected>,
 ): Signal<TSelected> {
-  return createReadonlySelectionSignal(source, selector, options)
+  const injector = resolveInjector(
+    injectSelector,
+    options?.injector,
+  )
+
+  return runInInjectionContext(injector, () => {
+    const _source = typeof source === "function" ? source : (() => source)
+
+    const slice = linkedSignal(() => selector(_source().get()), {
+      equal: options?.compare,
+    })
+
+    effect(() => {
+      const { unsubscribe } = _source().subscribe((state) => {
+        slice.set(selector(state))
+      })
+      return unsubscribe
+    })
+
+    return slice.asReadonly()
+  })
 }

--- a/packages/angular-store/tests/index.test.ts
+++ b/packages/angular-store/tests/index.test.ts
@@ -1,7 +1,16 @@
 import { describe, expect, test } from 'vitest'
-import { Component, effect } from '@angular/core'
+import {
+  Component,
+  computed,
+  effect,
+  input,
+  inputBinding,
+  signal,
+  untracked,
+} from '@angular/core'
 import { TestBed } from '@angular/core/testing'
 import { By } from '@angular/platform-browser'
+import { render } from '@testing-library/angular'
 import { Store, createAtom, createStore } from '@tanstack/store'
 import {
   _injectStore,
@@ -11,6 +20,10 @@ import {
   injectStore,
 } from '../src/index'
 import type { Atom } from '@tanstack/store'
+
+function createStableSignal<T>(fn: () => T): () => T {
+  return computed(() => untracked(fn))
+}
 
 describe('atom hooks', () => {
   test('injectSelector reads mutable atom state and rerenders when updated', () => {
@@ -114,6 +127,34 @@ describe('atom hooks', () => {
     fixture.detectChanges()
 
     expect(fixture.nativeElement.textContent).toContain('Value: 0')
+  })
+
+  test('injectAtom supports atoms created from input signals', async () => {
+    @Component({
+      template: `<p>{{ doubled() }}</p>`,
+      standalone: true,
+    })
+    class AtomFromInputChildCmp {
+      value = input.required<number>()
+      atom = createStableSignal(() => createAtom(this.value() * 2))
+      doubled = injectAtom(this.atom)
+
+      constructor() {
+        effect(() => {
+          this.doubled.set(this.value() * 2)
+        })
+      }
+    }
+
+    const value = signal(3)
+    const { getByText, findByText } = await render(AtomFromInputChildCmp, {
+      bindings: [inputBinding('value', value)],
+    })
+
+    expect(getByText('6')).toBeInTheDocument()
+
+    value.set(4)
+    expect(await findByText('8')).toBeInTheDocument()
   })
 })
 
@@ -363,6 +404,32 @@ describe('selector hooks', () => {
     expect(
       fixture.debugElement.query(By.css('p#derived')).nativeElement.textContent,
     ).toContain('2')
+  })
+
+  test('injectSelector supports selectors that read input signals', async () => {
+    const selectorReadsInputStore = createStore({ cats: 2, dogs: 4 })
+
+    @Component({
+      template: `<p>{{ count() }}</p>`,
+      standalone: true,
+    })
+    class SelectorReadsInputChildCmp {
+      animal = input.required<'cats' | 'dogs'>()
+      count = injectSelector(
+        selectorReadsInputStore,
+        (state) => state[this.animal()],
+      )
+    }
+
+    const animal = signal<'cats' | 'dogs'>('cats')
+    const { getByText, findByText } = await render(SelectorReadsInputChildCmp, {
+      bindings: [inputBinding('animal', animal)],
+    })
+
+    expect(getByText('2')).toBeInTheDocument()
+
+    animal.set('dogs')
+    expect(await findByText('4')).toBeInTheDocument()
   })
 })
 

--- a/packages/angular-store/tests/index.test.ts
+++ b/packages/angular-store/tests/index.test.ts
@@ -557,7 +557,7 @@ describe('_injectStore', () => {
       standalone: true,
     })
     class MyCmp {
-      private value = _injectStore(store, (state) => state)
+      protected value = _injectStore(store, (state) => state)
 
       inc() {
         this.value.setState((prev: number) => prev + 1)

--- a/packages/angular-store/tests/index.test.ts
+++ b/packages/angular-store/tests/index.test.ts
@@ -5,6 +5,7 @@ import {
   effect,
   input,
   inputBinding,
+  isSignal,
   signal,
   untracked,
 } from '@angular/core'
@@ -496,6 +497,14 @@ describe('dataType', () => {
 })
 
 describe('_injectStore', () => {
+  test('return value passes isSignal (proxies the selector signal)', () => {
+    TestBed.runInInjectionContext(() => {
+      const store = createStore(0)
+      const slice = _injectStore(store, (s) => s)
+      expect(isSignal(slice)).toBe(true)
+    })
+  })
+
   test('returns selected state and actions for stores with actions', () => {
     const store = createStore({ count: 0 }, ({ setState }) => ({
       inc: () => setState((prev) => ({ count: prev.count + 1 })),
@@ -511,12 +520,10 @@ describe('_injectStore', () => {
       standalone: true,
     })
     class MyCmp {
-      private result = _injectStore(store, (state) => state.count)
-      count = this.result[0]
-      actions = this.result[1]
+      protected count = _injectStore(store, (state) => state.count)
 
       inc() {
-        this.actions.inc()
+        this.count.inc()
       }
     }
 
@@ -550,12 +557,10 @@ describe('_injectStore', () => {
       standalone: true,
     })
     class MyCmp {
-      private result = _injectStore(store, (state) => state)
-      value = this.result[0]
-      setState = this.result[1]
+      private value = _injectStore(store, (state) => state)
 
       inc() {
-        this.setState((prev) => prev + 1)
+        this.value.setState((prev: number) => prev + 1)
       }
     }
 

--- a/packages/angular-store/tests/test-setup.ts
+++ b/packages/angular-store/tests/test-setup.ts
@@ -1,12 +1,5 @@
-import '@analogjs/vite-plugin-angular/setup-vitest'
+import '@testing-library/jest-dom/vitest'
+import '@angular/compiler'
+import { setupTestBed } from '@analogjs/vitest-angular/setup-testbed'
 
-import {
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting,
-} from '@angular/platform-browser-dynamic/testing'
-import { getTestBed } from '@angular/core/testing'
-
-getTestBed().initTestEnvironment(
-  BrowserDynamicTestingModule,
-  platformBrowserDynamicTesting(),
-)
+setupTestBed()

--- a/packages/angular-store/tests/test.test-d.ts
+++ b/packages/angular-store/tests/test.test-d.ts
@@ -73,22 +73,24 @@ test('createStoreContext preserves typed context shape', () => {
   expectTypeOf(ctx.petStore).toEqualTypeOf<Store<{ cats: number }>>()
 })
 
-test('_injectStore returns actions for stores with actions', () => {
+test('_injectStore returns callable slice with actions for stores with actions', () => {
   const store = createStore({ count: 0 }, ({ setState }) => ({
     inc: () => setState((prev) => ({ count: prev.count + 1 })),
   }))
 
-  const [selected, actions] = _injectStore(store, (state) => state.count)
+  const slice = _injectStore(store, (state) => state.count)
 
-  expectTypeOf(selected).toEqualTypeOf<Signal<number>>()
-  expectTypeOf(actions.inc).toBeFunction()
+  expectTypeOf(slice).toEqualTypeOf<
+    Signal<number> & { inc: () => void }
+  >()
 })
 
-test('_injectStore returns setState for plain stores', () => {
+test('_injectStore returns callable slice with setState for plain stores', () => {
   const store = createStore(0)
 
-  const [selected, setState] = _injectStore(store, (state) => state)
+  const slice = _injectStore(store, (state) => state)
 
-  expectTypeOf(selected).toEqualTypeOf<Signal<number>>()
-  expectTypeOf(setState).toEqualTypeOf<Store<number>['setState']>()
+  expectTypeOf(slice).toEqualTypeOf<
+    Signal<number> & { setState: Store<number>['setState'] }
+  >()
 })

--- a/packages/angular-store/tsconfig.spec.json
+++ b/packages/angular-store/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "types": ["vitest/globals", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["tests/**/*.ts"]
+}

--- a/packages/angular-store/tsconfig.spec.json
+++ b/packages/angular-store/tsconfig.spec.json
@@ -4,6 +4,6 @@
     "noEmit": false,
     "types": ["vitest/globals", "node"]
   },
-  "files": ["src/test-setup.ts"],
+  "files": ["tests/test-setup.ts"],
   "include": ["tests/**/*.ts"]
 }

--- a/packages/angular-store/vitest.config.ts
+++ b/packages/angular-store/vitest.config.ts
@@ -1,7 +1,9 @@
 import { defineConfig } from 'vitest/config'
+import angular from '@analogjs/vite-plugin-angular'
 import packageJson from './package.json'
 
 export default defineConfig({
+  plugins: [angular({ tsconfig: './tsconfig.spec.json' })],
   test: {
     name: packageJson.name,
     dir: './tests',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -970,6 +970,9 @@ importers:
       '@analogjs/vite-plugin-angular':
         specifier: ^2.4.5
         version: 2.4.5(cd1678fbfdd77b23b6bdbf3f09017a19)
+      '@analogjs/vitest-angular':
+        specifier: ^2.3.1
+        version: 2.5.2(@analogjs/vite-plugin-angular@2.4.5(cd1678fbfdd77b23b6bdbf3f09017a19))(@angular-devkit/architect@0.2102.7(chokidar@5.0.0))(@angular-devkit/schematics@21.2.7(chokidar@5.0.0))(vitest@4.1.4)(zone.js@0.16.1)
       '@angular/common':
         specifier: ^21.2.8
         version: 21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2)
@@ -982,9 +985,12 @@ importers:
       '@angular/platform-browser':
         specifier: ^21.2.8
         version: 21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))
-      '@angular/platform-browser-dynamic':
-        specifier: ^21.2.8
-        version: 21.2.8(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/compiler@21.2.8)(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))
+      '@testing-library/angular':
+        specifier: ^19.1.1
+        version: 19.3.0(693b1d0eacad9113f48af6b0f6cdf656)
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
       zone.js:
         specifier: ^0.16.1
         version: 0.16.1
@@ -1216,6 +1222,18 @@ packages:
       '@angular-devkit/build-angular':
         optional: true
       '@angular/build':
+        optional: true
+
+  '@analogjs/vitest-angular@2.5.2':
+    resolution: {integrity: sha512-wd9gNF0jJTOjiljeDO3M64QbcYFm3K0+KEG6bEAU9pX6J1Qgag4z9e0ZxlL1X2vRrYe087z+tbX8rp5tezPzuA==}
+    peerDependencies:
+      '@analogjs/vite-plugin-angular': '*'
+      '@angular-devkit/architect': '>=0.1500.0 < 0.2200.0'
+      '@angular-devkit/schematics': '>=17.0.0'
+      vitest: ^1.3.1 || ^2.0.0 || ^3.0.0 || ^4.0.0
+      zone.js: '>=0.14.0'
+    peerDependenciesMeta:
+      zone.js:
         optional: true
 
   '@angular-devkit/architect@0.2102.7':
@@ -4136,6 +4154,15 @@ packages:
   '@tanstack/typedoc-config@0.3.3':
     resolution: {integrity: sha512-wVT2YfKDSpd+4f7fk6UaPIP3a2J7LSovlyVuFF1PH2yQb7gjqehod5zdFiwFyEXgvI9XGuFvvs1OehkKNYcr6A==}
     engines: {node: '>=18'}
+
+  '@testing-library/angular@19.3.0':
+    resolution: {integrity: sha512-Wy2qpepHXOPSnTfH3NX0i9TZPTTrX+Bumd1u3UFJgl0N/iMLfCc9/LNIZCmbUFbT7t2pVLgXFL0kLHa5JuBy6A==}
+    peerDependencies:
+      '@angular/common': '>= 21.0.0'
+      '@angular/core': '>= 21.0.0'
+      '@angular/platform-browser': '>= 21.0.0'
+      '@angular/router': '>= 21.0.0'
+      '@testing-library/dom': ^10.0.0
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -9214,6 +9241,15 @@ snapshots:
       '@angular-devkit/build-angular': 21.2.7(@angular/compiler-cli@21.2.8(@angular/compiler@21.2.8)(typescript@6.0.2))(@angular/compiler@21.2.8)(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(lightningcss@1.32.0)(typescript@6.0.2)(vitest@4.1.4)(yaml@2.8.3)
       '@angular/build': 21.2.7(@angular/compiler-cli@21.2.8(@angular/compiler@21.2.8)(typescript@6.0.2))(@angular/compiler@21.2.8)(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)(@types/node@25.6.0)(chokidar@5.0.0)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.32.0)(postcss@8.5.14)(terser@5.46.0)(tslib@2.8.1)(typescript@6.0.2)(vitest@4.1.4)(yaml@2.8.3)
 
+  '@analogjs/vitest-angular@2.5.2(@analogjs/vite-plugin-angular@2.4.5(cd1678fbfdd77b23b6bdbf3f09017a19))(@angular-devkit/architect@0.2102.7(chokidar@5.0.0))(@angular-devkit/schematics@21.2.7(chokidar@5.0.0))(vitest@4.1.4)(zone.js@0.16.1)':
+    dependencies:
+      '@analogjs/vite-plugin-angular': 2.4.5(cd1678fbfdd77b23b6bdbf3f09017a19)
+      '@angular-devkit/architect': 0.2102.7(chokidar@5.0.0)
+      '@angular-devkit/schematics': 21.2.7(chokidar@5.0.0)
+      vitest: 4.1.4(@types/node@25.6.0)(@vitest/coverage-istanbul@4.1.4)(jsdom@29.0.2)(vite@8.0.13(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.8.3))
+    optionalDependencies:
+      zone.js: 0.16.1
+
   '@angular-devkit/architect@0.2102.7(chokidar@5.0.0)':
     dependencies:
       '@angular-devkit/core': 21.2.7(chokidar@5.0.0)
@@ -12111,6 +12147,15 @@ snapshots:
       typedoc-plugin-markdown: 4.9.0(typedoc@0.28.14(typescript@6.0.2))
     transitivePeerDependencies:
       - typescript
+
+  '@testing-library/angular@19.3.0(693b1d0eacad9113f48af6b0f6cdf656)':
+    dependencies:
+      '@angular/common': 21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2)
+      '@angular/core': 21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)
+      '@angular/platform-browser': 21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))
+      '@angular/router': 21.2.8(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(@angular/platform-browser@21.2.8(@angular/animations@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(@angular/common@21.2.8(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1))(rxjs@7.8.2))(@angular/core@21.2.8(@angular/compiler@21.2.8)(rxjs@7.8.2)(zone.js@0.16.1)))(rxjs@7.8.2)
+      '@testing-library/dom': 10.4.1
+      tslib: 2.8.1
 
   '@testing-library/dom@10.4.1':
     dependencies:


### PR DESCRIPTION
## 🎯 Changes

- Adds support to input signals by allowing the first argument to be a function that returns the store
- Correctly supports selectors with input signals by running the selector only in effects and linkedSignal.
- Migrates angular tests to use testing library, like the other adapters

A full [write out can be found here](https://github.com/benjavicente/tanstack-angular-store-input-examples#readme).

The main idea is that in Angular we can't call input signals on component initialization, so this fails:

```ts
export function injectRelativeTimestamp(timestamp: Signal<number>) {
  // Throws NG0952/NG0950: no model/input available yet
  const relativeTimestamp = new RelativeTime(timestamp());
}
```

By allowing a function/signal, we can allow consumers to lazy initialize the store, demonstrated by a couple of tests where `createStableSignal` (`computed(() => untracked(fn))`) is used. A previous PR I made #285 added that helper in the library, but since in React we are using `useState` or `useRef` without a helper to do the same idea (keeping a stable reference to the store), this PR does not provide a similar helper. Consumers are expected to keep the store getter function/signal stable.

## ✅ Checklist

- [X] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [X] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [X] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Atoms, selectors and stores can be provided lazily via factory functions.
  * Store injection now returns a callable signal-like slice that combines value access with actions (or setState).

* **Documentation**
  * Updated signatures and examples to reflect lazy inputs and the callable slice API.

* **Tests / Tooling**
  * Tests migrated to Angular signal APIs and centralized test runner; typings and test cases updated.

* **Examples**
  * Example app wiring adjusted to use the new callable slice.

* **Chores**
  * Test config and dev tooling dependencies updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/store/pull/291?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->