### PR TITLE
docs: code block formatting from `html` to `vue`

### DIFF
--- a/docs/framework/vue/quick-start.md
+++ b/docs/framework/vue/quick-start.md
@@ -6,7 +6,7 @@ id: quick-start
 The basic vue app example to get started with the TanStack vue-store.
 
 **App.vue**
-```html
+```vue
 <script setup>
 import Increment from './Increment.vue';
 import Display from './Display.vue';
@@ -43,7 +43,7 @@ export function updateState(animal) {
 ```
 
 **Display.vue**
-```html
+```vue
 <script setup>
 import { useStore } from '@tanstack/vue-store';
 import { store } from './store';
@@ -59,7 +59,7 @@ const count = useStore(store, (state) => state[props.animal]);
 ```
 
 **Increment.vue**
-```html
+```vue
 <script setup>
 import { store, updateState } from './store';
 


### PR DESCRIPTION
## 🎯 Changes

I changed the code formatting language for the code blocks in the vue examples from `html` to `vue` for correct syntax highlighting of the .vue files displayed in `quick-start.md`

<!-- What changes are made in this PR? Describe the change and its motivation. -->

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Improved syntax highlighting for Vue code snippets in the quick-start guide for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->