### PR TITLE
fix(docs): capitalize function names in API Reference (camelCase → PascalCase)

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -92,55 +92,55 @@
         },
         {
           "label": "Interfaces / Atom",
-          "to": "reference/interfaces/atom"
+          "to": "reference/interfaces/Atom"
         },
         {
           "label": "Interfaces / AtomOptions",
-          "to": "reference/interfaces/atomoptions"
+          "to": "reference/interfaces/AtomOptions"
         },
         {
           "label": "Interfaces / BaseAtom",
-          "to": "reference/interfaces/baseatom"
+          "to": "reference/interfaces/BaseAtom"
         },
         {
           "label": "Interfaces / InternalBaseAtom",
-          "to": "reference/interfaces/internalbaseatom"
+          "to": "reference/interfaces/InternalBaseAtom"
         },
         {
           "label": "Interfaces / InternalReadonlyAtom",
-          "to": "reference/interfaces/internalreadonlyatom"
+          "to": "reference/interfaces/InternalReadonlyAtom"
         },
         {
           "label": "Interfaces / InteropSubscribable",
-          "to": "reference/interfaces/interopsubscribable"
+          "to": "reference/interfaces/InteropSubscribable"
         },
         {
           "label": "Interfaces / Readable",
-          "to": "reference/interfaces/readable"
+          "to": "reference/interfaces/Readable"
         },
         {
           "label": "Interfaces / ReadonlyAtom",
-          "to": "reference/interfaces/readonlyatom"
+          "to": "reference/interfaces/ReadonlyAtom"
         },
         {
           "label": "Interfaces / Subscribable",
-          "to": "reference/interfaces/subscribable"
+          "to": "reference/interfaces/Subscribable"
         },
         {
           "label": "Interfaces / Subscription",
-          "to": "reference/interfaces/subscription"
+          "to": "reference/interfaces/Subscription"
         },
         {
           "label": "Type Aliases / AnyAtom",
-          "to": "reference/type-aliases/anyatom"
+          "to": "reference/type-aliases/AnyAtom"
         },
         {
           "label": "Type Aliases / Observer",
-          "to": "reference/type-aliases/observer"
+          "to": "reference/type-aliases/Observer"
         },
         {
           "label": "Type Aliases / Selection",
-          "to": "reference/type-aliases/selection"
+          "to": "reference/type-aliases/Selection"
         },
         {
           "label": "Functions / batch",
@@ -148,15 +148,15 @@
         },
         {
           "label": "Functions / createAsyncAtom",
-          "to": "reference/functions/createasyncatom"
+          "to": "reference/functions/CreateAsyncAtom"
         },
         {
           "label": "Functions / createAtom",
-          "to": "reference/functions/createatom"
+          "to": "reference/functions/CreateAtom"
         },
         {
           "label": "Functions / createStore",
-          "to": "reference/functions/createstore"
+          "to": "reference/functions/CreateStore"
         },
         {
           "label": "Functions / flush",
@@ -164,7 +164,7 @@
         },
         {
           "label": "Functions / toObserver",
-          "to": "reference/functions/toobserver"
+          "to": "reference/functions/ToObserver"    
         }
       ],
       "frameworks": [


### PR DESCRIPTION

## 🎯 Changes

- Updates docs/config.json to fix the documentation configuration.
- Corrects the docs navigation/reference setup so the docs structure matches the intended project layout.
- This is a documentation-only change and does not affect runtime behaviour.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API Reference navigation paths to use consistent PascalCase formatting for interfaces, type aliases, and function references, improving consistency and navigation accuracy in the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->