### PR TITLE
fix(docs): correct reference page path casing

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -92,55 +92,55 @@
         },
         {
           "label": "Interfaces / Atom",
-          "to": "reference/interfaces/atom"
+          "to": "reference/interfaces/Atom"
         },
         {
           "label": "Interfaces / AtomOptions",
-          "to": "reference/interfaces/atomoptions"
+          "to": "reference/interfaces/AtomOptions"
         },
         {
           "label": "Interfaces / BaseAtom",
-          "to": "reference/interfaces/baseatom"
+          "to": "reference/interfaces/BaseAtom"
         },
         {
           "label": "Interfaces / InternalBaseAtom",
-          "to": "reference/interfaces/internalbaseatom"
+          "to": "reference/interfaces/InternalBaseAtom"
         },
         {
           "label": "Interfaces / InternalReadonlyAtom",
-          "to": "reference/interfaces/internalreadonlyatom"
+          "to": "reference/interfaces/InternalReadonlyAtom"
         },
         {
           "label": "Interfaces / InteropSubscribable",
-          "to": "reference/interfaces/interopsubscribable"
+          "to": "reference/interfaces/InteropSubscribable"
         },
         {
           "label": "Interfaces / Readable",
-          "to": "reference/interfaces/readable"
+          "to": "reference/interfaces/Readable"
         },
         {
           "label": "Interfaces / ReadonlyAtom",
-          "to": "reference/interfaces/readonlyatom"
+          "to": "reference/interfaces/ReadonlyAtom"
         },
         {
           "label": "Interfaces / Subscribable",
-          "to": "reference/interfaces/subscribable"
+          "to": "reference/interfaces/Subscribable"
         },
         {
           "label": "Interfaces / Subscription",
-          "to": "reference/interfaces/subscription"
+          "to": "reference/interfaces/Subscription"
         },
         {
           "label": "Type Aliases / AnyAtom",
-          "to": "reference/type-aliases/anyatom"
+          "to": "reference/type-aliases/AnyAtom"
         },
         {
           "label": "Type Aliases / Observer",
-          "to": "reference/type-aliases/observer"
+          "to": "reference/type-aliases/Observer"
         },
         {
           "label": "Type Aliases / Selection",
-          "to": "reference/type-aliases/selection"
+          "to": "reference/type-aliases/Selection"
         },
         {
           "label": "Functions / batch",
@@ -148,15 +148,15 @@
         },
         {
           "label": "Functions / createAsyncAtom",
-          "to": "reference/functions/createasyncatom"
+          "to": "reference/functions/createAsyncAtom"
         },
         {
           "label": "Functions / createAtom",
-          "to": "reference/functions/createatom"
+          "to": "reference/functions/createAtom"
         },
         {
           "label": "Functions / createStore",
-          "to": "reference/functions/createstore"
+          "to": "reference/functions/createStore"
         },
         {
           "label": "Functions / flush",
@@ -164,7 +164,7 @@
         },
         {
           "label": "Functions / toObserver",
-          "to": "reference/functions/toobserver"
+          "to": "reference/functions/toObserver"
         }
       ],
       "frameworks": [


### PR DESCRIPTION
## 🎯 Changes

- Previously, pages like https://tanstack.com/store/latest/docs/reference/interfaces/atomoptions crashed with: "Unexpectedly client reference export 'notFound' is called on server".

<img width="1368" height="273" alt="Screenshot 2026-04-16 at 5 33 30 AM" src="https://github.com/user-attachments/assets/aa3aa29f-c93b-41bc-af9b-595410b56cb1" />

- This happened because the API reference sidebar config used incorrect route casing for generated docs pages.
- This change updates those paths to the correct routes, fixing the broken page.



## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed API Reference navigation links by correcting casing to match documentation page names, ensuring users can reliably access the intended reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->