### PR TITLE
chore: enforce pnpm 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
     "url": "https://github.com/tanstack/store.git"
   },
   "packageManager": "pnpm@10.33.0",
+  "engines": {
+    "pnpm": ">=11.0.0"
+  },
   "type": "module",
   "scripts": {
     "clean": "pnpm --filter \"./packages/**\" run clean",


### PR DESCRIPTION
Adds `engines.pnpm >=11.0.0` to TanStack/store.

| Scenario | Result |
|---|---|
| `pnpm@11+ install` | Allowed |
| `pnpm@11+ run ...` | Allowed |
| `pnpm@9 install` | Blocked by `engines.pnpm` |
| `pnpm@9 run ...` | Blocked by `engines.pnpm` |
| `pnpm@10 install` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 run ...` with default pnpm version management | Usually hands off to `packageManager` and runs as the declared pnpm version |
| `pnpm@10 install` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@10 run ...` with version handoff disabled | Blocked by `engines.pnpm` |
| `pnpm@9/10 list` | Not blocked |
| `pnpm@9/10 exec ...` | Not blocked |

| Field | What It Does |
|---|---|
| `packageManager` | Helps tools/newer pnpm select or hand off to the declared pnpm version |
| `engines.pnpm: ">=11.0.0"` | Fails important project workflows when an older pnpm is actually executing them |
| `engines.pnpm` | Does not intercept every pnpm subcommand |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project to require pnpm version 11.0.0 or higher as the package manager.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/TanStack/store/pull/332?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->