### PR TITLE
fix(svelte-store): use $state.raw in useSelector to prevent proxy equality mismatch

### DIFF
--- a/.changeset/fix-svelte-store-proxy-equality.md
+++ b/.changeset/fix-svelte-store-proxy-equality.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/svelte-store': patch
+---
+
+Fix `state_proxy_equality_mismatch` warning in `useSelector` by using `$state.raw()` instead of `$state()` for the slice variable. `$state()` wrapped object values in a Svelte Proxy, causing `===` comparison with the raw selector output to always fail, which triggered unnecessary re-renders and Svelte runtime warnings on every store update.

--- a/packages/svelte-store/src/useSelector.svelte.ts
+++ b/packages/svelte-store/src/useSelector.svelte.ts
@@ -35,7 +35,9 @@ export function useSelector<TState, TSelected = NoInfer<TState>>(
   options: UseSelectorOptions<TSelected> = {},
 ): { readonly current: TSelected } {
   const compare = options.compare ?? defaultCompare
-  let slice = $state(selector(source.get()))
+  // `$state.raw` keeps the slice unproxied; a proxied value would never be `===`
+  // to the plain object the selector returns, defeating the equality check below.
+  let slice = $state.raw(selector(source.get()))
 
   $effect(() => {
     const unsub = source.subscribe((s) => {

--- a/packages/svelte-store/tests/ProxyEquality.test.svelte
+++ b/packages/svelte-store/tests/ProxyEquality.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+  import { createStore } from '@tanstack/store'
+  import { useSelector } from '../src/index.svelte.js'
+
+  const store = createStore({
+    selected: { value: 1 },
+    ignored: 0,
+  })
+
+  const selected = useSelector(store, (state) => state.selected)
+
+  let renderCount = $state(0)
+
+  $effect(() => {
+    selected.current
+    untrack(() => {
+      renderCount++
+    })
+  })
+</script>
+
+<div>
+  <p>Number rendered: {renderCount}</p>
+  <p>Value: {selected.current.value}</p>
+  <button
+    onclick={() =>
+      store.setState((v) => ({
+        ...v,
+        ignored: v.ignored + 1,
+      }))}
+  >
+    Update ignored
+  </button>
+</div>

--- a/packages/svelte-store/tests/SelectorMemoization.test.svelte
+++ b/packages/svelte-store/tests/SelectorMemoization.test.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+  import { untrack } from 'svelte'
+  import { createStore } from '@tanstack/store'
+  import { useSelector } from '../src/index.svelte.js'
+
+  // Three arms driven by one button, so a failure says *why* it failed:
+  //   default    object slice compared with the library's own `===`
+  //   keyed      object slice behind a compare no proxy can fool   (control)
+  //   primitive  string slice, which Svelte never proxies          (control)
+  // Proxying the slice breaks only the first arm, which pins the cause to the
+  // proxy rather than to the store or the subscription.
+
+  // Each selected slice keeps ONE identity for the whole run; only the
+  // unrelated `ignored` field ever changes. That is precisely what a selector
+  // exists to memoize, so a correct one wakes its readers exactly once.
+  const DEFAULT_SELECTED = { id: 'stable', rows: ['a', 'b'] }
+  const KEYED_SELECTED = { id: 'stable', rows: ['a', 'b'] }
+
+  const defaultStore = createStore({ selected: DEFAULT_SELECTED, ignored: 0 })
+  const keyedStore = createStore({ selected: KEYED_SELECTED, ignored: 0 })
+  const primitiveStore = createStore({ label: 'constant', ignored: 0 })
+
+  const defaultSlice = useSelector(defaultStore, (state) => state.selected)
+  const keyedSlice = useSelector(keyedStore, (state) => state.selected, {
+    compare: (a, b) => a.id === b.id,
+  })
+  const primitiveSlice = useSelector(primitiveStore, (state) => state.label)
+
+  let defaultRenders = $state(0)
+  let keyedRenders = $state(0)
+  let primitiveRenders = $state(0)
+  let defaultIdentities = $state(0)
+  let sameObject = $state(false)
+
+  // Re-setting the slice mints a fresh Proxy each time, so counting identities
+  // separates "notified again" from "notified with something genuinely new".
+  // Deliberately a plain Set rather than a SvelteSet: the instrument must stay
+  // outside the reactivity it measures.
+  // eslint-disable-next-line svelte/prefer-svelte-reactivity
+  const seen = new Set()
+
+  $effect(() => {
+    const current = defaultSlice.current
+    untrack(() => {
+      defaultRenders++
+      seen.add(current)
+      defaultIdentities = seen.size
+      // Compiled to Svelte's instrumented `===`, which warns only when the two
+      // sides are the same underlying object yet `===` reports otherwise.
+      sameObject = current === DEFAULT_SELECTED
+    })
+  })
+
+  $effect(() => {
+    keyedSlice.current
+    untrack(() => {
+      keyedRenders++
+    })
+  })
+
+  $effect(() => {
+    primitiveSlice.current
+    untrack(() => {
+      primitiveRenders++
+    })
+  })
+
+  function updateIgnored() {
+    defaultStore.setState((v) => ({ ...v, ignored: v.ignored + 1 }))
+    keyedStore.setState((v) => ({ ...v, ignored: v.ignored + 1 }))
+    primitiveStore.setState((v) => ({ ...v, ignored: v.ignored + 1 }))
+  }
+</script>
+
+<div>
+  <p>Default renders: {defaultRenders}</p>
+  <p>Default identities: {defaultIdentities}</p>
+  <p>Same object: {sameObject}</p>
+  <p>Keyed renders: {keyedRenders}</p>
+  <p>Primitive renders: {primitiveRenders}</p>
+  <button onclick={updateIgnored}>Update ignored</button>
+</div>

--- a/packages/svelte-store/tests/index.test.ts
+++ b/packages/svelte-store/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, test } from 'vitest'
+import { describe, expect, it, test, vi } from 'vitest'
 import { render, waitFor } from '@testing-library/svelte'
 import { userEvent } from '@testing-library/user-event'
 import { shallow } from '../src/index.svelte.js'
@@ -6,8 +6,18 @@ import TestBaseStore from './BaseStore.test.svelte'
 import TestRerender from './Render.test.svelte'
 import TestValue from './Value.test.svelte'
 import TestProxyEquality from './ProxyEquality.test.svelte'
+import TestSelectorMemoization from './SelectorMemoization.test.svelte'
 
 const user = userEvent.setup()
+
+/** Three updates that leave the selected slice untouched, each clicked
+ *  separately: Svelte coalesces a synchronous burst into a single effect run,
+ *  which would hide a cost paid once per notification. */
+async function threeUnrelatedUpdates(button: HTMLElement) {
+  for (let i = 0; i < 3; i++) {
+    await user.click(button)
+  }
+}
 
 describe('useSelector', () => {
   it('allows us to select state using a selector', () => {
@@ -35,6 +45,56 @@ describe('useSelector', () => {
 
     await user.click(getByText('Update ignored'))
     expect(getByText('Number rendered: 1')).toBeInTheDocument()
+  })
+
+  it('memoizes an unchanged object slice on every notification', async () => {
+    const { getByText } = render(TestSelectorMemoization)
+    expect(getByText('Default renders: 1')).toBeInTheDocument()
+
+    await threeUnrelatedUpdates(getByText('Update ignored'))
+
+    // The slice never changed, so a memoizing selector still reads 1 / 1 here.
+    // A proxied slice compares unequal to the raw object it wraps, re-sets the
+    // slice, and hands out a brand-new Proxy: 4 renders over 4 identities.
+    expect(getByText('Default renders: 1')).toBeInTheDocument()
+    expect(getByText('Default identities: 1')).toBeInTheDocument()
+    // `.current` is the very object the store holds, not a wrapper over it.
+    expect(getByText('Same object: true')).toBeInTheDocument()
+  })
+
+  it('memoizes the same slice under both controls', async () => {
+    const { getByText } = render(TestSelectorMemoization)
+
+    await threeUnrelatedUpdates(getByText('Update ignored'))
+
+    // A compare no proxy can fool, and a primitive slice that is never proxied.
+    // Neither arm regresses when the object arm does, which is what isolates
+    // the cause to the proxying rather than to the store or the subscription.
+    expect(getByText('Keyed renders: 1')).toBeInTheDocument()
+    expect(getByText('Primitive renders: 1')).toBeInTheDocument()
+  })
+
+  it('compares the slice without tripping a proxy-equality warning', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const { getByText } = render(TestSelectorMemoization)
+
+      await threeUnrelatedUpdates(getByText('Update ignored'))
+
+      // Svelte warns here only when the operands are one underlying object yet
+      // `===` disagrees, so this asserts the compare sees through no wrapper.
+      const warned = warn.mock.calls
+        .flat()
+        .some(
+          (arg) =>
+            typeof arg === 'string' &&
+            arg.includes('state_proxy_equality_mismatch'),
+        )
+      expect(warned).toBe(false)
+    } finally {
+      warn.mockRestore()
+    }
   })
 
   it('useSelector reads writable and readonly store state', async () => {

--- a/packages/svelte-store/tests/index.test.ts
+++ b/packages/svelte-store/tests/index.test.ts
@@ -5,6 +5,7 @@ import { shallow } from '../src/index.svelte.js'
 import TestBaseStore from './BaseStore.test.svelte'
 import TestRerender from './Render.test.svelte'
 import TestValue from './Value.test.svelte'
+import TestProxyEquality from './ProxyEquality.test.svelte'
 
 const user = userEvent.setup()
 
@@ -26,6 +27,14 @@ describe('useSelector', () => {
 
     await user.click(getByText('Update ignored'))
     expect(getByText('Number rendered: 2')).toBeInTheDocument()
+  })
+
+  it('does not trigger re-render when selector returns same object reference', async () => {
+    const { getByText } = render(TestProxyEquality)
+    expect(getByText('Number rendered: 1')).toBeInTheDocument()
+
+    await user.click(getByText('Update ignored'))
+    expect(getByText('Number rendered: 1')).toBeInTheDocument()
   })
 
   it('useSelector reads writable and readonly store state', async () => {


### PR DESCRIPTION
## 🎯 Changes

 Fixes #322

  `$state()` wraps object values in a Svelte Proxy. When `selector(s)` returns the same
  raw object reference, `===` comparison with the Proxy always fails — triggering
  `state_proxy_equality_mismatch` warnings and unnecessary re-renders even when the
  selected value hasn't changed.
  
  Existing tests only covered primitive selectors, which are not Proxy-wrapped. A new test
  with an object selector reproduces the issue and verifies the fix.

  Switching to `$state.raw()` is safe since `useSelector` only ever reassigns `slice`,
  never mutates its properties.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [ ] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed `useSelector` selector equality handling to prevent `state_proxy_equality_mismatch` warnings and unnecessary re-renders when the selected value is effectively unchanged.
* **Tests**
  * Added and expanded Svelte tests covering proxy equality and selector memoization, including scenarios where unrelated store fields update.
* **Chores**
  * Added a release metadata entry documenting the patch fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->