### PR TITLE
fix: inline reactive flags in store build

### DIFF
--- a/.changeset/tidy-flags-shake.md
+++ b/.changeset/tidy-flags-shake.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/store': patch
+---
+
+Inline reactive flag constants in generated builds to improve tree-shaking.

--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -9,7 +9,7 @@ title: batch
 function batch(fn): void;
 ```
 
-Defined in: [atom.ts:62](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L62)
+Defined in: [atom.ts:70](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L70)
 
 ## Parameters
 

--- a/docs/reference/functions/createAsyncAtom.md
+++ b/docs/reference/functions/createAsyncAtom.md
@@ -9,7 +9,7 @@ title: createAsyncAtom
 function createAsyncAtom<T>(getValue, options?): ReadonlyAtom<AsyncAtomState<T, unknown>>;
 ```
 
-Defined in: [atom.ts:100](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L100)
+Defined in: [atom.ts:108](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L108)
 
 ## Type Parameters
 

--- a/docs/reference/functions/createAtom.md
+++ b/docs/reference/functions/createAtom.md
@@ -11,7 +11,7 @@ title: createAtom
 function createAtom<T>(getValue, options?): ReadonlyAtom<T>;
 ```
 
-Defined in: [atom.ts:138](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L138)
+Defined in: [atom.ts:146](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L146)
 
 ### Type Parameters
 
@@ -39,7 +39,7 @@ Defined in: [atom.ts:138](https://github.com/TanStack/store/blob/main/packages/s
 function createAtom<T>(initialValue, options?): Atom<T>;
 ```
 
-Defined in: [atom.ts:142](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L142)
+Defined in: [atom.ts:150](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L150)
 
 ### Type Parameters
 

--- a/docs/reference/functions/flush.md
+++ b/docs/reference/functions/flush.md
@@ -9,7 +9,7 @@ title: flush
 function flush(): void;
 ```
 
-Defined in: [atom.ts:81](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L81)
+Defined in: [atom.ts:89](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L89)
 
 ## Returns
 

--- a/docs/reference/functions/toObserver.md
+++ b/docs/reference/functions/toObserver.md
@@ -12,7 +12,7 @@ function toObserver<T>(
 completionHandler?): Observer<T>;
 ```
 
-Defined in: [atom.ts:12](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L12)
+Defined in: [atom.ts:20](https://github.com/TanStack/store/blob/main/packages/store/src/atom.ts#L20)
 
 ## Type Parameters
 

--- a/docs/reference/interfaces/InternalReadonlyAtom.md
+++ b/docs/reference/interfaces/InternalReadonlyAtom.md
@@ -67,7 +67,7 @@ Defined in: [types.ts:39](https://github.com/TanStack/store/blob/main/packages/s
 optional deps: Link;
 ```
 
-Defined in: [alien.ts:16](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L16)
+Defined in: [alien.ts:6](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L6)
 
 #### Inherited from
 
@@ -83,7 +83,7 @@ ReactiveNode.deps
 optional depsTail: Link;
 ```
 
-Defined in: [alien.ts:17](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L17)
+Defined in: [alien.ts:7](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L7)
 
 #### Inherited from
 
@@ -99,7 +99,7 @@ ReactiveNode.depsTail
 flags: number;
 ```
 
-Defined in: [alien.ts:20](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L20)
+Defined in: [alien.ts:10](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L10)
 
 #### Inherited from
 
@@ -133,7 +133,7 @@ Defined in: [types.ts:30](https://github.com/TanStack/store/blob/main/packages/s
 optional subs: Link;
 ```
 
-Defined in: [alien.ts:18](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L18)
+Defined in: [alien.ts:8](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L8)
 
 #### Inherited from
 
@@ -163,7 +163,7 @@ Defined in: [types.ts:21](https://github.com/TanStack/store/blob/main/packages/s
 optional subsTail: Link;
 ```
 
-Defined in: [alien.ts:19](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L19)
+Defined in: [alien.ts:9](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L9)
 
 #### Inherited from
 

--- a/docs/reference/interfaces/InternalReadonlyAtom.md
+++ b/docs/reference/interfaces/InternalReadonlyAtom.md
@@ -96,7 +96,7 @@ ReactiveNode.depsTail
 ### flags
 
 ```ts
-flags: ReactiveFlags;
+flags: number;
 ```
 
 Defined in: [alien.ts:10](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L10)

--- a/docs/reference/interfaces/InternalReadonlyAtom.md
+++ b/docs/reference/interfaces/InternalReadonlyAtom.md
@@ -67,7 +67,7 @@ Defined in: [types.ts:39](https://github.com/TanStack/store/blob/main/packages/s
 optional deps: Link;
 ```
 
-Defined in: [alien.ts:6](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L6)
+Defined in: [alien.ts:16](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L16)
 
 #### Inherited from
 
@@ -83,7 +83,7 @@ ReactiveNode.deps
 optional depsTail: Link;
 ```
 
-Defined in: [alien.ts:7](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L7)
+Defined in: [alien.ts:17](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L17)
 
 #### Inherited from
 
@@ -99,7 +99,7 @@ ReactiveNode.depsTail
 flags: number;
 ```
 
-Defined in: [alien.ts:10](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L10)
+Defined in: [alien.ts:20](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L20)
 
 #### Inherited from
 
@@ -133,7 +133,7 @@ Defined in: [types.ts:30](https://github.com/TanStack/store/blob/main/packages/s
 optional subs: Link;
 ```
 
-Defined in: [alien.ts:8](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L8)
+Defined in: [alien.ts:18](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L18)
 
 #### Inherited from
 
@@ -163,7 +163,7 @@ Defined in: [types.ts:21](https://github.com/TanStack/store/blob/main/packages/s
 optional subsTail: Link;
 ```
 
-Defined in: [alien.ts:9](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L9)
+Defined in: [alien.ts:19](https://github.com/TanStack/store/blob/main/packages/store/src/alien.ts#L19)
 
 #### Inherited from
 

--- a/knip.json
+++ b/knip.json
@@ -1,10 +1,12 @@
 {
   "$schema": "https://unpkg.com/knip@5/schema.json",
   "workspaces": {
+    "packages/store": {
+      "entry": ["src/signal.ts"]
+    },
     "packages/vue-store": {
       "ignoreDependencies": ["vue2", "vue2.7"]
     }
   },
-  "ignoreWorkspaces": ["examples/**"],
-  "ignore": ["packages/store/src/signal.ts"]
+  "ignoreWorkspaces": ["examples/**"]
 }

--- a/packages/store/src/alien.ts
+++ b/packages/store/src/alien.ts
@@ -31,7 +31,7 @@ export const NONE = 0
 export const MUTABLE = 1
 export const WATCHING = 2
 export const RECURSED_CHECK = 4
-export const RECURSED = 8
+const RECURSED = 8
 export const DIRTY = 16
 export const PENDING = 32
 /*@__NO_SIDE_EFFECTS__*/

--- a/packages/store/src/alien.ts
+++ b/packages/store/src/alien.ts
@@ -2,16 +2,6 @@
 // Adapted from Alien Signals
 // https://github.com/stackblitz/alien-signals/
 
-import {
-  DIRTY,
-  MUTABLE,
-  NONE,
-  PENDING,
-  RECURSED,
-  RECURSED_CHECK,
-  WATCHING,
-} from './flags'
-
 export interface ReactiveNode {
   deps?: Link
   depsTail?: Link
@@ -36,6 +26,14 @@ interface Stack<T> {
 }
 
 export type ReactiveFlags = number
+
+export const NONE = 0
+export const MUTABLE = 1
+export const WATCHING = 2
+export const RECURSED_CHECK = 4
+export const RECURSED = 8
+export const DIRTY = 16
+export const PENDING = 32
 /*@__NO_SIDE_EFFECTS__*/
 export function createReactiveSystem({
   update,

--- a/packages/store/src/alien.ts
+++ b/packages/store/src/alien.ts
@@ -25,15 +25,15 @@ interface Stack<T> {
   prev: Stack<T> | undefined
 }
 
-export const enum ReactiveFlags {
-  None = 0,
-  Mutable = 1,
-  Watching = 2,
-  RecursedCheck = 4,
-  Recursed = 8,
-  Dirty = 16,
-  Pending = 32,
-}
+export type ReactiveFlags = number
+
+export const NONE = 0
+export const MUTABLE = 1
+export const WATCHING = 2
+export const RECURSED_CHECK = 4
+export const RECURSED = 8
+export const DIRTY = 16
+export const PENDING = 32
 /*@__NO_SIDE_EFFECTS__*/
 export function createReactiveSystem({
   update,
@@ -135,37 +135,24 @@ export function createReactiveSystem({
       const sub = link.sub
       let flags = sub.flags
 
-      if (
-        !(
-          flags &
-          (ReactiveFlags.RecursedCheck |
-            ReactiveFlags.Recursed |
-            ReactiveFlags.Dirty |
-            ReactiveFlags.Pending)
-        )
-      ) {
-        sub.flags = flags | ReactiveFlags.Pending
-      } else if (
-        !(flags & (ReactiveFlags.RecursedCheck | ReactiveFlags.Recursed))
-      ) {
-        flags = ReactiveFlags.None
-      } else if (!(flags & ReactiveFlags.RecursedCheck)) {
-        sub.flags = (flags & ~ReactiveFlags.Recursed) | ReactiveFlags.Pending
-      } else if (
-        !(flags & (ReactiveFlags.Dirty | ReactiveFlags.Pending)) &&
-        isValidLink(link, sub)
-      ) {
-        sub.flags = flags | (ReactiveFlags.Recursed | ReactiveFlags.Pending)
-        flags &= ReactiveFlags.Mutable
+      if (!(flags & (RECURSED_CHECK | RECURSED | DIRTY | PENDING))) {
+        sub.flags = flags | PENDING
+      } else if (!(flags & (RECURSED_CHECK | RECURSED))) {
+        flags = NONE
+      } else if (!(flags & RECURSED_CHECK)) {
+        sub.flags = (flags & ~RECURSED) | PENDING
+      } else if (!(flags & (DIRTY | PENDING)) && isValidLink(link, sub)) {
+        sub.flags = flags | (RECURSED | PENDING)
+        flags &= MUTABLE
       } else {
-        flags = ReactiveFlags.None
+        flags = NONE
       }
 
-      if (flags & ReactiveFlags.Watching) {
+      if (flags & WATCHING) {
         notify(sub)
       }
 
-      if (flags & ReactiveFlags.Mutable) {
+      if (flags & MUTABLE) {
         const subSubs = sub.subs
         if (subSubs !== undefined) {
           const nextSub = (link = subSubs).nextSub
@@ -204,12 +191,9 @@ export function createReactiveSystem({
       const dep = link.dep
       const flags = dep.flags
 
-      if (sub.flags & ReactiveFlags.Dirty) {
+      if (sub.flags & DIRTY) {
         dirty = true
-      } else if (
-        (flags & (ReactiveFlags.Mutable | ReactiveFlags.Dirty)) ===
-        (ReactiveFlags.Mutable | ReactiveFlags.Dirty)
-      ) {
+      } else if ((flags & (MUTABLE | DIRTY)) === (MUTABLE | DIRTY)) {
         if (update(dep)) {
           const subs = dep.subs!
           if (subs.nextSub !== undefined) {
@@ -217,10 +201,7 @@ export function createReactiveSystem({
           }
           dirty = true
         }
-      } else if (
-        (flags & (ReactiveFlags.Mutable | ReactiveFlags.Pending)) ===
-        (ReactiveFlags.Mutable | ReactiveFlags.Pending)
-      ) {
+      } else if ((flags & (MUTABLE | PENDING)) === (MUTABLE | PENDING)) {
         if (link.nextSub !== undefined || link.prevSub !== undefined) {
           stack = { value: link, prev: stack }
         }
@@ -257,7 +238,7 @@ export function createReactiveSystem({
           }
           dirty = false
         } else {
-          sub.flags &= ~ReactiveFlags.Pending
+          sub.flags &= ~PENDING
         }
         sub = link.sub
         const nextDep = link.nextDep
@@ -275,15 +256,9 @@ export function createReactiveSystem({
     do {
       const sub = link.sub
       const flags = sub.flags
-      if (
-        (flags & (ReactiveFlags.Pending | ReactiveFlags.Dirty)) ===
-        ReactiveFlags.Pending
-      ) {
-        sub.flags = flags | ReactiveFlags.Dirty
-        if (
-          (flags & (ReactiveFlags.Watching | ReactiveFlags.RecursedCheck)) ===
-          ReactiveFlags.Watching
-        ) {
+      if ((flags & (PENDING | DIRTY)) === PENDING) {
+        sub.flags = flags | DIRTY
+        if ((flags & (WATCHING | RECURSED_CHECK)) === WATCHING) {
           notify(sub)
         }
       }

--- a/packages/store/src/alien.ts
+++ b/packages/store/src/alien.ts
@@ -2,6 +2,16 @@
 // Adapted from Alien Signals
 // https://github.com/stackblitz/alien-signals/
 
+import {
+  DIRTY,
+  MUTABLE,
+  NONE,
+  PENDING,
+  RECURSED,
+  RECURSED_CHECK,
+  WATCHING,
+} from './flags'
+
 export interface ReactiveNode {
   deps?: Link
   depsTail?: Link
@@ -26,14 +36,6 @@ interface Stack<T> {
 }
 
 export type ReactiveFlags = number
-
-export const NONE = 0
-export const MUTABLE = 1
-export const WATCHING = 2
-export const RECURSED_CHECK = 4
-const RECURSED = 8
-export const DIRTY = 16
-export const PENDING = 32
 /*@__NO_SIDE_EFFECTS__*/
 export function createReactiveSystem({
   update,

--- a/packages/store/src/atom.ts
+++ b/packages/store/src/atom.ts
@@ -1,4 +1,3 @@
-import { createReactiveSystem } from './alien'
 import {
   DIRTY,
   MUTABLE,
@@ -6,7 +5,8 @@ import {
   PENDING,
   RECURSED_CHECK,
   WATCHING,
-} from './flags'
+  createReactiveSystem,
+} from './alien'
 
 import type { ReactiveNode } from './alien'
 import type {

--- a/packages/store/src/atom.ts
+++ b/packages/store/src/atom.ts
@@ -1,3 +1,4 @@
+import { createReactiveSystem } from './alien'
 import {
   DIRTY,
   MUTABLE,
@@ -5,8 +6,7 @@ import {
   PENDING,
   RECURSED_CHECK,
   WATCHING,
-  createReactiveSystem,
-} from './alien'
+} from './flags'
 
 import type { ReactiveNode } from './alien'
 import type {

--- a/packages/store/src/atom.ts
+++ b/packages/store/src/atom.ts
@@ -1,4 +1,12 @@
-import { ReactiveFlags, createReactiveSystem } from './alien'
+import {
+  DIRTY,
+  MUTABLE,
+  NONE,
+  PENDING,
+  RECURSED_CHECK,
+  WATCHING,
+  createReactiveSystem,
+} from './alien'
 
 import type { ReactiveNode } from './alien'
 import type {
@@ -43,12 +51,12 @@ const { link, unlink, propagate, checkDirty, shallowPropagate } =
     // eslint-disable-next-line no-shadow
     notify(effect: Effect): void {
       queuedEffects[queuedEffectsLength++] = effect
-      effect.flags &= ~ReactiveFlags.Watching
+      effect.flags &= ~WATCHING
     },
     unwatched(atom: InternalAtom<any>): void {
       if (atom.depsTail !== undefined) {
         atom.depsTail = undefined
-        atom.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty
+        atom.flags = MUTABLE | DIRTY
         purgeDeps(atom)
       }
     },
@@ -158,7 +166,7 @@ export function createAtom<T>(
     subsTail: undefined,
     deps: undefined,
     depsTail: undefined,
-    flags: isComputed ? ReactiveFlags.None : ReactiveFlags.Mutable,
+    flags: isComputed ? NONE : MUTABLE,
 
     get(): T {
       if (activeSub !== undefined) {
@@ -198,7 +206,7 @@ export function createAtom<T>(
         return false
       }
       if (isComputed) {
-        atom.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck
+        atom.flags = MUTABLE | RECURSED_CHECK
       }
       try {
         const oldValue = atom._snapshot
@@ -216,7 +224,7 @@ export function createAtom<T>(
       } finally {
         activeSub = prevSub
         if (isComputed) {
-          atom.flags &= ~ReactiveFlags.RecursedCheck
+          atom.flags &= ~RECURSED_CHECK
         }
         purgeDeps(atom)
       }
@@ -224,21 +232,18 @@ export function createAtom<T>(
   }
 
   if (isComputed) {
-    atom.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty
+    atom.flags = MUTABLE | DIRTY
     atom.get = function (): T {
       const flags = atom.flags
-      if (
-        flags & ReactiveFlags.Dirty ||
-        (flags & ReactiveFlags.Pending && checkDirty(atom.deps!, atom))
-      ) {
+      if (flags & DIRTY || (flags & PENDING && checkDirty(atom.deps!, atom))) {
         if (atom._update()) {
           const subs = atom.subs
           if (subs !== undefined) {
             shallowPropagate(subs)
           }
         }
-      } else if (flags & ReactiveFlags.Pending) {
-        atom.flags = flags & ~ReactiveFlags.Pending
+      } else if (flags & PENDING) {
+        atom.flags = flags & ~PENDING
       }
       if (activeSub !== undefined) {
         link(atom, activeSub, cycle)
@@ -275,12 +280,12 @@ function effect<T>(fn: () => T): Effect {
     activeSub = effectObj
     ++cycle
     effectObj.depsTail = undefined
-    effectObj.flags = ReactiveFlags.Watching | ReactiveFlags.RecursedCheck
+    effectObj.flags = WATCHING | RECURSED_CHECK
     try {
       return fn()
     } finally {
       activeSub = prevSub
-      effectObj.flags &= ~ReactiveFlags.RecursedCheck
+      effectObj.flags &= ~RECURSED_CHECK
       purgeDeps(effectObj)
     }
   }
@@ -289,22 +294,19 @@ function effect<T>(fn: () => T): Effect {
     depsTail: undefined,
     subs: undefined,
     subsTail: undefined,
-    flags: ReactiveFlags.Watching | ReactiveFlags.RecursedCheck,
+    flags: WATCHING | RECURSED_CHECK,
 
     notify(): void {
       const flags = this.flags
-      if (
-        flags & ReactiveFlags.Dirty ||
-        (flags & ReactiveFlags.Pending && checkDirty(this.deps!, this))
-      ) {
+      if (flags & DIRTY || (flags & PENDING && checkDirty(this.deps!, this))) {
         run()
       } else {
-        this.flags = ReactiveFlags.Watching
+        this.flags = WATCHING
       }
     },
 
     stop(): void {
-      this.flags = ReactiveFlags.None
+      this.flags = NONE
       this.depsTail = undefined
       purgeDeps(this)
     },

--- a/packages/store/src/flags.ts
+++ b/packages/store/src/flags.ts
@@ -1,0 +1,7 @@
+export const NONE = 0
+export const MUTABLE = 1
+export const WATCHING = 2
+export const RECURSED_CHECK = 4
+export const RECURSED = 8
+export const DIRTY = 16
+export const PENDING = 32

--- a/packages/store/src/flags.ts
+++ b/packages/store/src/flags.ts
@@ -1,7 +1,0 @@
-export const NONE = 0
-export const MUTABLE = 1
-export const WATCHING = 2
-export const RECURSED_CHECK = 4
-export const RECURSED = 8
-export const DIRTY = 16
-export const PENDING = 32

--- a/packages/store/src/signal.ts
+++ b/packages/store/src/signal.ts
@@ -2,12 +2,21 @@
 // Adapted from Alien Signals
 // https://github.com/stackblitz/alien-signals/
 
-import { ReactiveFlags, createReactiveSystem } from './alien'
+import {
+  DIRTY,
+  MUTABLE,
+  NONE,
+  PENDING,
+  RECURSED,
+  RECURSED_CHECK,
+  WATCHING,
+  createReactiveSystem,
+} from './alien'
 
 import type { ReactiveNode } from './alien'
 
-export { ReactiveFlags, createReactiveSystem } from './alien'
-export type { Link, ReactiveNode } from './alien'
+export { createReactiveSystem } from './alien'
+export type { Link, ReactiveFlags, ReactiveNode } from './alien'
 
 interface EffectNode extends ReactiveNode {
   fn(): void
@@ -45,9 +54,9 @@ const { link, unlink, propagate, checkDirty, shallowPropagate } =
 
       do {
         queued[insertIndex++] = effect
-        effect.flags &= ~ReactiveFlags.Watching
+        effect.flags &= ~WATCHING
         effect = effect.subs?.sub as EffectNode
-        if (effect === undefined || !(effect.flags & ReactiveFlags.Watching)) {
+        if (effect === undefined || !(effect.flags & WATCHING)) {
           break
         }
       } while (true)
@@ -61,11 +70,11 @@ const { link, unlink, propagate, checkDirty, shallowPropagate } =
       }
     },
     unwatched(node) {
-      if (!(node.flags & ReactiveFlags.Mutable)) {
+      if (!(node.flags & MUTABLE)) {
         effectScopeOper.call(node)
       } else if (node.depsTail !== undefined) {
         node.depsTail = undefined
-        node.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty
+        node.flags = MUTABLE | DIRTY
         purgeDeps(node)
       }
     },
@@ -128,7 +137,7 @@ export function signal<T>(initialValue?: T): {
     pendingValue: initialValue,
     subs: undefined,
     subsTail: undefined,
-    flags: ReactiveFlags.Mutable,
+    flags: MUTABLE,
   }) as () => T | undefined
 }
 
@@ -139,7 +148,7 @@ export function computed<T>(getter: (previousValue?: T) => T): () => T {
     subsTail: undefined,
     deps: undefined,
     depsTail: undefined,
-    flags: ReactiveFlags.None,
+    flags: NONE,
     getter: getter as (previousValue?: unknown) => unknown,
   }) as () => T
 }
@@ -151,7 +160,7 @@ export function effect(fn: () => void): () => void {
     subsTail: undefined,
     deps: undefined,
     depsTail: undefined,
-    flags: ReactiveFlags.Watching | ReactiveFlags.RecursedCheck,
+    flags: WATCHING | RECURSED_CHECK,
   }
   const prevSub = setActiveSub(e)
   if (prevSub !== undefined) {
@@ -161,7 +170,7 @@ export function effect(fn: () => void): () => void {
     e.fn()
   } finally {
     activeSub = prevSub
-    e.flags &= ~ReactiveFlags.RecursedCheck
+    e.flags &= ~RECURSED_CHECK
   }
   return effectOper.bind(e)
 }
@@ -172,7 +181,7 @@ export function effectScope(fn: () => void): () => void {
     depsTail: undefined,
     subs: undefined,
     subsTail: undefined,
-    flags: ReactiveFlags.None,
+    flags: NONE,
   }
   const prevSub = setActiveSub(e)
   if (prevSub !== undefined) {
@@ -190,7 +199,7 @@ export function trigger(fn: () => void) {
   const sub: ReactiveNode = {
     deps: undefined,
     depsTail: undefined,
-    flags: ReactiveFlags.Watching,
+    flags: WATCHING,
   }
   const prevSub = setActiveSub(sub)
   try {
@@ -203,7 +212,7 @@ export function trigger(fn: () => void) {
       link = unlink(link, sub)
       const subs = dep.subs
       if (subs !== undefined) {
-        sub.flags = ReactiveFlags.None
+        sub.flags = NONE
         propagate(subs)
         shallowPropagate(subs)
       }
@@ -217,42 +226,39 @@ export function trigger(fn: () => void) {
 function updateComputed(c: ComputedNode): boolean {
   ++cycle
   c.depsTail = undefined
-  c.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck
+  c.flags = MUTABLE | RECURSED_CHECK
   const prevSub = setActiveSub(c)
   try {
     const oldValue = c.value
     return oldValue !== (c.value = c.getter(oldValue))
   } finally {
     activeSub = prevSub
-    c.flags &= ~ReactiveFlags.RecursedCheck
+    c.flags &= ~RECURSED_CHECK
     purgeDeps(c)
   }
 }
 
 function updateSignal(s: SignalNode): boolean {
-  s.flags = ReactiveFlags.Mutable
+  s.flags = MUTABLE
   return s.currentValue !== (s.currentValue = s.pendingValue)
 }
 
 function run(e: EffectNode): void {
   const flags = e.flags
-  if (
-    flags & ReactiveFlags.Dirty ||
-    (flags & ReactiveFlags.Pending && checkDirty(e.deps!, e))
-  ) {
+  if (flags & DIRTY || (flags & PENDING && checkDirty(e.deps!, e))) {
     ++cycle
     e.depsTail = undefined
-    e.flags = ReactiveFlags.Watching | ReactiveFlags.RecursedCheck
+    e.flags = WATCHING | RECURSED_CHECK
     const prevSub = setActiveSub(e)
     try {
       ;(e as EffectNode).fn()
     } finally {
       activeSub = prevSub
-      e.flags &= ~ReactiveFlags.RecursedCheck
+      e.flags &= ~RECURSED_CHECK
       purgeDeps(e)
     }
   } else {
-    e.flags = ReactiveFlags.Watching
+    e.flags = WATCHING
   }
 }
 
@@ -267,7 +273,7 @@ function flush(): void {
     while (notifyIndex < queuedLength) {
       const effect = queued[notifyIndex]!
       queued[notifyIndex++] = undefined
-      effect.flags |= ReactiveFlags.Watching | ReactiveFlags.Recursed
+      effect.flags |= WATCHING | RECURSED
     }
     notifyIndex = 0
     queuedLength = 0
@@ -277,10 +283,10 @@ function flush(): void {
 function computedOper<T>(this: ComputedNode<T>): T {
   const flags = this.flags
   if (
-    flags & ReactiveFlags.Dirty ||
-    (flags & ReactiveFlags.Pending &&
+    flags & DIRTY ||
+    (flags & PENDING &&
       (checkDirty(this.deps!, this) ||
-        ((this.flags = flags & ~ReactiveFlags.Pending), false)))
+        ((this.flags = flags & ~PENDING), false)))
   ) {
     if (updateComputed(this)) {
       const subs = this.subs
@@ -289,13 +295,13 @@ function computedOper<T>(this: ComputedNode<T>): T {
       }
     }
   } else if (!flags) {
-    this.flags = ReactiveFlags.Mutable | ReactiveFlags.RecursedCheck
+    this.flags = MUTABLE | RECURSED_CHECK
     const prevSub = setActiveSub(this)
     try {
       this.value = this.getter()
     } finally {
       activeSub = prevSub
-      this.flags &= ~ReactiveFlags.RecursedCheck
+      this.flags &= ~RECURSED_CHECK
     }
   }
   const sub = activeSub
@@ -308,7 +314,7 @@ function computedOper<T>(this: ComputedNode<T>): T {
 function signalOper<T>(this: SignalNode<T>, ...value: [T]): T | void {
   if (value.length) {
     if (this.pendingValue !== (this.pendingValue = value[0])) {
-      this.flags = ReactiveFlags.Mutable | ReactiveFlags.Dirty
+      this.flags = MUTABLE | DIRTY
       const subs = this.subs
       if (subs !== undefined) {
         propagate(subs)
@@ -318,7 +324,7 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T]): T | void {
       }
     }
   } else {
-    if (this.flags & ReactiveFlags.Dirty) {
+    if (this.flags & DIRTY) {
       if (updateSignal(this)) {
         const subs = this.subs
         if (subs !== undefined) {
@@ -328,7 +334,7 @@ function signalOper<T>(this: SignalNode<T>, ...value: [T]): T | void {
     }
     let sub = activeSub
     while (sub !== undefined) {
-      if (sub.flags & (ReactiveFlags.Mutable | ReactiveFlags.Watching)) {
+      if (sub.flags & (MUTABLE | WATCHING)) {
         link(this, sub, cycle)
         break
       }
@@ -344,7 +350,7 @@ function effectOper(this: EffectNode): void {
 
 function effectScopeOper(this: ReactiveNode): void {
   this.depsTail = undefined
-  this.flags = ReactiveFlags.None
+  this.flags = NONE
   purgeDeps(this)
   const sub = this.subs
   if (sub !== undefined) {

--- a/packages/store/src/signal.ts
+++ b/packages/store/src/signal.ts
@@ -7,7 +7,6 @@ import {
   MUTABLE,
   NONE,
   PENDING,
-  RECURSED,
   RECURSED_CHECK,
   WATCHING,
   createReactiveSystem,
@@ -17,6 +16,8 @@ import type { ReactiveNode } from './alien'
 
 export { createReactiveSystem } from './alien'
 export type { Link, ReactiveFlags, ReactiveNode } from './alien'
+
+const RECURSED = 8
 
 interface EffectNode extends ReactiveNode {
   fn(): void

--- a/packages/store/src/signal.ts
+++ b/packages/store/src/signal.ts
@@ -2,22 +2,21 @@
 // Adapted from Alien Signals
 // https://github.com/stackblitz/alien-signals/
 
+import { createReactiveSystem } from './alien'
 import {
   DIRTY,
   MUTABLE,
   NONE,
   PENDING,
+  RECURSED,
   RECURSED_CHECK,
   WATCHING,
-  createReactiveSystem,
-} from './alien'
+} from './flags'
 
 import type { ReactiveNode } from './alien'
 
 export { createReactiveSystem } from './alien'
 export type { Link, ReactiveFlags, ReactiveNode } from './alien'
-
-const RECURSED = 8
 
 interface EffectNode extends ReactiveNode {
   fn(): void

--- a/packages/store/src/signal.ts
+++ b/packages/store/src/signal.ts
@@ -2,7 +2,6 @@
 // Adapted from Alien Signals
 // https://github.com/stackblitz/alien-signals/
 
-import { createReactiveSystem } from './alien'
 import {
   DIRTY,
   MUTABLE,
@@ -11,7 +10,8 @@ import {
   RECURSED,
   RECURSED_CHECK,
   WATCHING,
-} from './flags'
+  createReactiveSystem,
+} from './alien'
 
 import type { ReactiveNode } from './alien'
 


### PR DESCRIPTION
## Summary

- replace the runtime-emitted `ReactiveFlags` const enum with shared numeric constants
- update Store reactive internals to use constants that tsdown can inline
- preserve `ReactiveFlags` as a type without changing runtime behavior

The generated ESM now contains numeric flag operations, and `atom.js` imports only `createReactiveSystem` from `alien.js`.

**Results**

in `tanstack/router` we tried updating `tanstack/store` to `0.11.0`:

| Build | Gzip | Initial gzip | Raw | Brotli |
|---|---:|---:|---:|---:|
| Unpatched 0.11 | 89,251 B | 89,113 B | 276,120 B | 77,820 B |
| PR #350 preview | **89,069 B** | **88,926 B** | **275,317 B** | **77,508 B** |

PR #350 gives the following deltas:
- versus unpatched 0.11
  - `-182 B` gzip
  - `-803 B` raw
  - `-312 B` Brotli
- versus the original 0.9 baseline of `89,197 B`
  - `-128 B` gzip


## Testing

- `pnpm --filter @tanstack/store build`
- `pnpm --filter @tanstack/store test:build`
- `pnpm --filter @tanstack/store test:types`
- `pnpm --filter @tanstack/store test:lib --run`
- `pnpm --filter @tanstack/store test:eslint`
- Prettier check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated source links for reactive functions to point to their current definitions.
  * Corrected the documented type of `InternalReadonlyAtom.flags`.

* **Refactor**
  * Reworked reactive flag handling without changing observable reactive behavior.
  * Exposed numeric flag constants while retaining the `ReactiveFlags` type.

* **Chores**
  * Updated code analysis configuration to recognize the reactive system entry point.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->