### PR TITLE
docs: disable generated page titles

### DIFF
--- a/docs/framework/angular/reference/functions/createStoreContext.md
+++ b/docs/framework/angular/reference/functions/createStoreContext.md
@@ -3,8 +3,6 @@ id: createStoreContext
 title: createStoreContext
 ---
 
-# Function: createStoreContext()
-
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/angular/reference/functions/createStoreContext.md
+++ b/docs/framework/angular/reference/functions/createStoreContext.md
@@ -3,6 +3,8 @@ id: createStoreContext
 title: createStoreContext
 ---
 
+# Function: createStoreContext()
+
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/angular/reference/functions/injectAtom.md
+++ b/docs/framework/angular/reference/functions/injectAtom.md
@@ -3,8 +3,6 @@ id: injectAtom
 title: injectAtom
 ---
 
-# Function: injectAtom()
-
 ```ts
 function injectAtom<TValue>(atom, options?): WritableAtomSignal<TValue>;
 ```

--- a/docs/framework/angular/reference/functions/injectAtom.md
+++ b/docs/framework/angular/reference/functions/injectAtom.md
@@ -3,6 +3,8 @@ id: injectAtom
 title: injectAtom
 ---
 
+# Function: injectAtom()
+
 ```ts
 function injectAtom<TValue>(atom, options?): WritableAtomSignal<TValue>;
 ```

--- a/docs/framework/angular/reference/functions/injectSelector.md
+++ b/docs/framework/angular/reference/functions/injectSelector.md
@@ -3,8 +3,6 @@ id: injectSelector
 title: injectSelector
 ---
 
-# Function: injectSelector()
-
 ```ts
 function injectSelector<TState, TSelected>(
    source, 

--- a/docs/framework/angular/reference/functions/injectSelector.md
+++ b/docs/framework/angular/reference/functions/injectSelector.md
@@ -3,6 +3,8 @@ id: injectSelector
 title: injectSelector
 ---
 
+# Function: injectSelector()
+
 ```ts
 function injectSelector<TState, TSelected>(
    source, 

--- a/docs/framework/angular/reference/functions/injectStore-1.md
+++ b/docs/framework/angular/reference/functions/injectStore-1.md
@@ -3,6 +3,8 @@ id: injectStore
 title: injectStore
 ---
 
+# ~~Function: injectStore()~~
+
 ```ts
 function injectStore<TState, TSelected>(
    store, 

--- a/docs/framework/angular/reference/functions/injectStore-1.md
+++ b/docs/framework/angular/reference/functions/injectStore-1.md
@@ -3,8 +3,6 @@ id: injectStore
 title: injectStore
 ---
 
-# ~~Function: injectStore()~~
-
 ```ts
 function injectStore<TState, TSelected>(
    store, 

--- a/docs/framework/angular/reference/functions/injectStore.md
+++ b/docs/framework/angular/reference/functions/injectStore.md
@@ -3,6 +3,8 @@ id: _injectStore
 title: _injectStore
 ---
 
+# Function: \_injectStore()
+
 ```ts
 function _injectStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/angular/reference/functions/injectStore.md
+++ b/docs/framework/angular/reference/functions/injectStore.md
@@ -3,8 +3,6 @@ id: _injectStore
 title: _injectStore
 ---
 
-# Function: \_injectStore()
-
 ```ts
 function _injectStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/angular-store"
 title: "@tanstack/angular-store"
 ---
 
-# @tanstack/angular-store
-
 ## Interfaces
 
 - [InjectSelectorOptions](interfaces/InjectSelectorOptions.md)

--- a/docs/framework/angular/reference/index.md
+++ b/docs/framework/angular/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/angular-store"
 title: "@tanstack/angular-store"
 ---
 
+# @tanstack/angular-store
+
 ## Interfaces
 
 - [InjectSelectorOptions](interfaces/InjectSelectorOptions.md)

--- a/docs/framework/angular/reference/interfaces/InjectSelectorOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectSelectorOptions.md
@@ -3,6 +3,8 @@ id: InjectSelectorOptions
 title: InjectSelectorOptions
 ---
 
+# Interface: InjectSelectorOptions\<TSelected\>
+
 Defined in: [packages/angular-store/src/injectSelector.ts:11](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectSelector.ts#L11)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/InjectSelectorOptions.md
+++ b/docs/framework/angular/reference/interfaces/InjectSelectorOptions.md
@@ -3,8 +3,6 @@ id: InjectSelectorOptions
 title: InjectSelectorOptions
 ---
 
-# Interface: InjectSelectorOptions\<TSelected\>
-
 Defined in: [packages/angular-store/src/injectSelector.ts:11](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectSelector.ts#L11)
 
 ## Extends

--- a/docs/framework/angular/reference/interfaces/WritableAtomSignal.md
+++ b/docs/framework/angular/reference/interfaces/WritableAtomSignal.md
@@ -3,8 +3,6 @@ id: WritableAtomSignal
 title: WritableAtomSignal
 ---
 
-# Interface: WritableAtomSignal()\<T\>
-
 Defined in: [packages/angular-store/src/injectAtom.ts:21](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectAtom.ts#L21)
 
 A callable signal that reads the current atom value when invoked and

--- a/docs/framework/angular/reference/interfaces/WritableAtomSignal.md
+++ b/docs/framework/angular/reference/interfaces/WritableAtomSignal.md
@@ -3,6 +3,8 @@ id: WritableAtomSignal
 title: WritableAtomSignal
 ---
 
+# Interface: WritableAtomSignal()\<T\>
+
 Defined in: [packages/angular-store/src/injectAtom.ts:21](https://github.com/TanStack/store/blob/main/packages/angular-store/src/injectAtom.ts#L21)
 
 A callable signal that reads the current atom value when invoked and

--- a/docs/framework/angular/reference/type-aliases/SelectionSource.md
+++ b/docs/framework/angular/reference/type-aliases/SelectionSource.md
@@ -3,8 +3,6 @@ id: SelectionSource
 title: SelectionSource
 ---
 
-# Type Alias: SelectionSource\<T\>
-
 ```ts
 type SelectionSource<T> = object;
 ```

--- a/docs/framework/angular/reference/type-aliases/SelectionSource.md
+++ b/docs/framework/angular/reference/type-aliases/SelectionSource.md
@@ -3,6 +3,8 @@ id: SelectionSource
 title: SelectionSource
 ---
 
+# Type Alias: SelectionSource\<T\>
+
 ```ts
 type SelectionSource<T> = object;
 ```

--- a/docs/framework/octane/reference/functions/createStoreContext.md
+++ b/docs/framework/octane/reference/functions/createStoreContext.md
@@ -3,8 +3,6 @@ id: createStoreContext
 title: createStoreContext
 ---
 
-# Function: createStoreContext()
-
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/octane/reference/functions/createStoreContext.md
+++ b/docs/framework/octane/reference/functions/createStoreContext.md
@@ -3,6 +3,8 @@ id: createStoreContext
 title: createStoreContext
 ---
 
+# Function: createStoreContext()
+
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/octane/reference/functions/useAtom.md
+++ b/docs/framework/octane/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(
   atom,

--- a/docs/framework/octane/reference/functions/useAtom.md
+++ b/docs/framework/octane/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(
   atom,

--- a/docs/framework/octane/reference/functions/useCreateAtom.md
+++ b/docs/framework/octane/reference/functions/useCreateAtom.md
@@ -3,6 +3,8 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
+# Function: useCreateAtom()
+
 ## Readonly atom
 
 ```ts

--- a/docs/framework/octane/reference/functions/useCreateAtom.md
+++ b/docs/framework/octane/reference/functions/useCreateAtom.md
@@ -3,8 +3,6 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
-# Function: useCreateAtom()
-
 ## Readonly atom
 
 ```ts

--- a/docs/framework/octane/reference/functions/useCreateStore.md
+++ b/docs/framework/octane/reference/functions/useCreateStore.md
@@ -3,8 +3,6 @@ id: useCreateStore
 title: useCreateStore
 ---
 
-# Function: useCreateStore()
-
 ## Readonly store
 
 ```ts

--- a/docs/framework/octane/reference/functions/useCreateStore.md
+++ b/docs/framework/octane/reference/functions/useCreateStore.md
@@ -3,6 +3,8 @@ id: useCreateStore
 title: useCreateStore
 ---
 
+# Function: useCreateStore()
+
 ## Readonly store
 
 ```ts

--- a/docs/framework/octane/reference/functions/useSelector.md
+++ b/docs/framework/octane/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/octane/reference/functions/useSelector.md
+++ b/docs/framework/octane/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/octane/reference/index.md
+++ b/docs/framework/octane/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/octane-store"
 title: "@tanstack/octane-store"
 ---
 
+# @tanstack/octane-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/octane/reference/index.md
+++ b/docs/framework/octane/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/octane-store"
 title: "@tanstack/octane-store"
 ---
 
-# @tanstack/octane-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/octane/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/octane/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [octane-store/src/useSelector.ts:5](https://github.com/TanStack/store/blob/main/packages/octane-store/src/useSelector.ts#L5)
 
 ## Type Parameters

--- a/docs/framework/octane/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/octane/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [octane-store/src/useSelector.ts:5](https://github.com/TanStack/store/blob/main/packages/octane-store/src/useSelector.ts#L5)
 
 ## Type Parameters

--- a/docs/framework/preact/reference/functions/createStoreContext.md
+++ b/docs/framework/preact/reference/functions/createStoreContext.md
@@ -3,8 +3,6 @@ id: createStoreContext
 title: createStoreContext
 ---
 
-# Function: createStoreContext()
-
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/preact/reference/functions/createStoreContext.md
+++ b/docs/framework/preact/reference/functions/createStoreContext.md
@@ -3,6 +3,8 @@ id: createStoreContext
 title: createStoreContext
 ---
 
+# Function: createStoreContext()
+
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/preact/reference/functions/useAtom.md
+++ b/docs/framework/preact/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(atom, options?): [TValue, (fn) => void & (value) => void];
 ```

--- a/docs/framework/preact/reference/functions/useAtom.md
+++ b/docs/framework/preact/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(atom, options?): [TValue, (fn) => void & (value) => void];
 ```

--- a/docs/framework/preact/reference/functions/useCreateAtom.md
+++ b/docs/framework/preact/reference/functions/useCreateAtom.md
@@ -3,6 +3,8 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
+# Function: useCreateAtom()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useCreateAtom.md
+++ b/docs/framework/preact/reference/functions/useCreateAtom.md
@@ -3,8 +3,6 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
-# Function: useCreateAtom()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useCreateStore.md
+++ b/docs/framework/preact/reference/functions/useCreateStore.md
@@ -3,6 +3,8 @@ id: useCreateStore
 title: useCreateStore
 ---
 
+# Function: useCreateStore()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useCreateStore.md
+++ b/docs/framework/preact/reference/functions/useCreateStore.md
@@ -3,8 +3,6 @@ id: useCreateStore
 title: useCreateStore
 ---
 
-# Function: useCreateStore()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/preact/reference/functions/useSelector.md
+++ b/docs/framework/preact/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/preact/reference/functions/useSelector.md
+++ b/docs/framework/preact/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/preact/reference/functions/useStore-1.md
+++ b/docs/framework/preact/reference/functions/useStore-1.md
@@ -3,6 +3,8 @@ id: useStore
 title: useStore
 ---
 
+# ~~Function: useStore()~~
+
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/preact/reference/functions/useStore-1.md
+++ b/docs/framework/preact/reference/functions/useStore-1.md
@@ -3,8 +3,6 @@ id: useStore
 title: useStore
 ---
 
-# ~~Function: useStore()~~
-
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/preact/reference/functions/useStore.md
+++ b/docs/framework/preact/reference/functions/useStore.md
@@ -3,8 +3,6 @@ id: _useStore
 title: _useStore
 ---
 
-# Function: \_useStore()
-
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/preact/reference/functions/useStore.md
+++ b/docs/framework/preact/reference/functions/useStore.md
@@ -3,6 +3,8 @@ id: _useStore
 title: _useStore
 ---
 
+# Function: \_useStore()
+
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/preact-store"
 title: "@tanstack/preact-store"
 ---
 
+# @tanstack/preact-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/preact/reference/index.md
+++ b/docs/framework/preact/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/preact-store"
 title: "@tanstack/preact-store"
 ---
 
-# @tanstack/preact-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/preact/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [preact-store/src/useSelector.ts:9](https://github.com/TanStack/store/blob/main/packages/preact-store/src/useSelector.ts#L9)
 
 ## Type Parameters

--- a/docs/framework/preact/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/preact/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [preact-store/src/useSelector.ts:9](https://github.com/TanStack/store/blob/main/packages/preact-store/src/useSelector.ts#L9)
 
 ## Type Parameters

--- a/docs/framework/react/reference/functions/createStoreContext.md
+++ b/docs/framework/react/reference/functions/createStoreContext.md
@@ -3,8 +3,6 @@ id: createStoreContext
 title: createStoreContext
 ---
 
-# Function: createStoreContext()
-
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/react/reference/functions/createStoreContext.md
+++ b/docs/framework/react/reference/functions/createStoreContext.md
@@ -3,6 +3,8 @@ id: createStoreContext
 title: createStoreContext
 ---
 
+# Function: createStoreContext()
+
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/react/reference/functions/useAtom.md
+++ b/docs/framework/react/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(atom, options?): [TValue, (fn) => void & (value) => void];
 ```

--- a/docs/framework/react/reference/functions/useAtom.md
+++ b/docs/framework/react/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(atom, options?): [TValue, (fn) => void & (value) => void];
 ```

--- a/docs/framework/react/reference/functions/useCreateAtom.md
+++ b/docs/framework/react/reference/functions/useCreateAtom.md
@@ -3,6 +3,8 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
+# Function: useCreateAtom()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/react/reference/functions/useCreateAtom.md
+++ b/docs/framework/react/reference/functions/useCreateAtom.md
@@ -3,8 +3,6 @@ id: useCreateAtom
 title: useCreateAtom
 ---
 
-# Function: useCreateAtom()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/react/reference/functions/useCreateStore.md
+++ b/docs/framework/react/reference/functions/useCreateStore.md
@@ -3,6 +3,8 @@ id: useCreateStore
 title: useCreateStore
 ---
 
+# Function: useCreateStore()
+
 ## Call Signature
 
 ```ts

--- a/docs/framework/react/reference/functions/useCreateStore.md
+++ b/docs/framework/react/reference/functions/useCreateStore.md
@@ -3,8 +3,6 @@ id: useCreateStore
 title: useCreateStore
 ---
 
-# Function: useCreateStore()
-
 ## Call Signature
 
 ```ts

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/react/reference/functions/useStore-1.md
+++ b/docs/framework/react/reference/functions/useStore-1.md
@@ -3,6 +3,8 @@ id: useStore
 title: useStore
 ---
 
+# ~~Function: useStore()~~
+
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/react/reference/functions/useStore-1.md
+++ b/docs/framework/react/reference/functions/useStore-1.md
@@ -3,8 +3,6 @@ id: useStore
 title: useStore
 ---
 
-# ~~Function: useStore()~~
-
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/react/reference/functions/useStore.md
+++ b/docs/framework/react/reference/functions/useStore.md
@@ -3,8 +3,6 @@ id: _useStore
 title: _useStore
 ---
 
-# Function: \_useStore()
-
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/react/reference/functions/useStore.md
+++ b/docs/framework/react/reference/functions/useStore.md
@@ -3,6 +3,8 @@ id: _useStore
 title: _useStore
 ---
 
+# Function: \_useStore()
+
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/react/reference/index.md
+++ b/docs/framework/react/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/react-store"
 title: "@tanstack/react-store"
 ---
 
+# @tanstack/react-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/react/reference/index.md
+++ b/docs/framework/react/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/react-store"
 title: "@tanstack/react-store"
 ---
 
-# @tanstack/react-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/react/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/react/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [packages/react-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/framework/react/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/react/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [packages/react-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/framework/solid/reference/functions/createStoreContext.md
+++ b/docs/framework/solid/reference/functions/createStoreContext.md
@@ -3,8 +3,6 @@ id: createStoreContext
 title: createStoreContext
 ---
 
-# Function: createStoreContext()
-
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/solid/reference/functions/createStoreContext.md
+++ b/docs/framework/solid/reference/functions/createStoreContext.md
@@ -3,6 +3,8 @@ id: createStoreContext
 title: createStoreContext
 ---
 
+# Function: createStoreContext()
+
 ```ts
 function createStoreContext<TValue>(): object;
 ```

--- a/docs/framework/solid/reference/functions/useAtom.md
+++ b/docs/framework/solid/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(atom, options?): [Accessor<TValue>, (fn) => void & (value) => void];
 ```

--- a/docs/framework/solid/reference/functions/useAtom.md
+++ b/docs/framework/solid/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(atom, options?): [Accessor<TValue>, (fn) => void & (value) => void];
 ```

--- a/docs/framework/solid/reference/functions/useSelector.md
+++ b/docs/framework/solid/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/solid/reference/functions/useSelector.md
+++ b/docs/framework/solid/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/solid/reference/functions/useStore-1.md
+++ b/docs/framework/solid/reference/functions/useStore-1.md
@@ -3,6 +3,8 @@ id: useStore
 title: useStore
 ---
 
+# ~~Function: useStore()~~
+
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/solid/reference/functions/useStore-1.md
+++ b/docs/framework/solid/reference/functions/useStore-1.md
@@ -3,8 +3,6 @@ id: useStore
 title: useStore
 ---
 
-# ~~Function: useStore()~~
-
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/solid/reference/functions/useStore.md
+++ b/docs/framework/solid/reference/functions/useStore.md
@@ -3,8 +3,6 @@ id: _useStore
 title: _useStore
 ---
 
-# Function: \_useStore()
-
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/solid/reference/functions/useStore.md
+++ b/docs/framework/solid/reference/functions/useStore.md
@@ -3,6 +3,8 @@ id: _useStore
 title: _useStore
 ---
 
+# Function: \_useStore()
+
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/solid/reference/index.md
+++ b/docs/framework/solid/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/solid-store"
 title: "@tanstack/solid-store"
 ---
 
+# @tanstack/solid-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/solid/reference/index.md
+++ b/docs/framework/solid/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/solid-store"
 title: "@tanstack/solid-store"
 ---
 
-# @tanstack/solid-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/solid/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/solid/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [solid-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/solid-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/framework/solid/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/solid/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [solid-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/solid-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/framework/svelte/reference/functions/useAtom.md
+++ b/docs/framework/svelte/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(atom, options?): [{
   current: TValue;

--- a/docs/framework/svelte/reference/functions/useAtom.md
+++ b/docs/framework/svelte/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(atom, options?): [{
   current: TValue;

--- a/docs/framework/svelte/reference/functions/useSelector.md
+++ b/docs/framework/svelte/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TState, TSelected>(
    source, 

--- a/docs/framework/svelte/reference/functions/useSelector.md
+++ b/docs/framework/svelte/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TState, TSelected>(
    source, 

--- a/docs/framework/svelte/reference/functions/useStore-1.md
+++ b/docs/framework/svelte/reference/functions/useStore-1.md
@@ -3,6 +3,8 @@ id: useStore
 title: useStore
 ---
 
+# ~~Function: useStore()~~
+
 ```ts
 function useStore<TState, TSelected>(
    source, 

--- a/docs/framework/svelte/reference/functions/useStore-1.md
+++ b/docs/framework/svelte/reference/functions/useStore-1.md
@@ -3,8 +3,6 @@ id: useStore
 title: useStore
 ---
 
-# ~~Function: useStore()~~
-
 ```ts
 function useStore<TState, TSelected>(
    source, 

--- a/docs/framework/svelte/reference/functions/useStore.md
+++ b/docs/framework/svelte/reference/functions/useStore.md
@@ -3,8 +3,6 @@ id: _useStore
 title: _useStore
 ---
 
-# Function: \_useStore()
-
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/svelte/reference/functions/useStore.md
+++ b/docs/framework/svelte/reference/functions/useStore.md
@@ -3,6 +3,8 @@ id: _useStore
 title: _useStore
 ---
 
+# Function: \_useStore()
+
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/svelte/reference/index.md
+++ b/docs/framework/svelte/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/svelte-store"
 title: "@tanstack/svelte-store"
 ---
 
+# @tanstack/svelte-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/svelte/reference/index.md
+++ b/docs/framework/svelte/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/svelte-store"
 title: "@tanstack/svelte-store"
 ---
 
-# @tanstack/svelte-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/svelte/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/svelte/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [svelte-store/src/useSelector.svelte.ts:3](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/useSelector.svelte.ts#L3)
 
 ## Type Parameters

--- a/docs/framework/svelte/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/svelte/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [svelte-store/src/useSelector.svelte.ts:3](https://github.com/TanStack/store/blob/main/packages/svelte-store/src/useSelector.svelte.ts#L3)
 
 ## Type Parameters

--- a/docs/framework/vue/reference/functions/useAtom.md
+++ b/docs/framework/vue/reference/functions/useAtom.md
@@ -3,6 +3,8 @@ id: useAtom
 title: useAtom
 ---
 
+# Function: useAtom()
+
 ```ts
 function useAtom<TValue>(atom, options?): [Readonly<Ref<TValue, TValue>>, (fn) => void & (value) => void];
 ```

--- a/docs/framework/vue/reference/functions/useAtom.md
+++ b/docs/framework/vue/reference/functions/useAtom.md
@@ -3,8 +3,6 @@ id: useAtom
 title: useAtom
 ---
 
-# Function: useAtom()
-
 ```ts
 function useAtom<TValue>(atom, options?): [Readonly<Ref<TValue, TValue>>, (fn) => void & (value) => void];
 ```

--- a/docs/framework/vue/reference/functions/useSelector.md
+++ b/docs/framework/vue/reference/functions/useSelector.md
@@ -3,8 +3,6 @@ id: useSelector
 title: useSelector
 ---
 
-# Function: useSelector()
-
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/vue/reference/functions/useSelector.md
+++ b/docs/framework/vue/reference/functions/useSelector.md
@@ -3,6 +3,8 @@ id: useSelector
 title: useSelector
 ---
 
+# Function: useSelector()
+
 ```ts
 function useSelector<TSource, TSelected>(
    source, 

--- a/docs/framework/vue/reference/functions/useStore-1.md
+++ b/docs/framework/vue/reference/functions/useStore-1.md
@@ -3,6 +3,8 @@ id: useStore
 title: useStore
 ---
 
+# ~~Function: useStore()~~
+
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/vue/reference/functions/useStore-1.md
+++ b/docs/framework/vue/reference/functions/useStore-1.md
@@ -3,8 +3,6 @@ id: useStore
 title: useStore
 ---
 
-# ~~Function: useStore()~~
-
 ```ts
 function useStore<TSource, TSelected>(
    source, 

--- a/docs/framework/vue/reference/functions/useStore.md
+++ b/docs/framework/vue/reference/functions/useStore.md
@@ -3,8 +3,6 @@ id: _useStore
 title: _useStore
 ---
 
-# Function: \_useStore()
-
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/vue/reference/functions/useStore.md
+++ b/docs/framework/vue/reference/functions/useStore.md
@@ -3,6 +3,8 @@ id: _useStore
 title: _useStore
 ---
 
+# Function: \_useStore()
+
 ```ts
 function _useStore<TState, TActions, TSelected>(
    store, 

--- a/docs/framework/vue/reference/index.md
+++ b/docs/framework/vue/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/vue-store"
 title: "@tanstack/vue-store"
 ---
 
+# @tanstack/vue-store
+
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/vue/reference/index.md
+++ b/docs/framework/vue/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/vue-store"
 title: "@tanstack/vue-store"
 ---
 
-# @tanstack/vue-store
-
 ## Interfaces
 
 - [UseSelectorOptions](interfaces/UseSelectorOptions.md)

--- a/docs/framework/vue/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/vue/reference/interfaces/UseSelectorOptions.md
@@ -3,6 +3,8 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
+# Interface: UseSelectorOptions\<TSelected\>
+
 Defined in: [vue-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/vue-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/framework/vue/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/vue/reference/interfaces/UseSelectorOptions.md
@@ -3,8 +3,6 @@ id: UseSelectorOptions
 title: UseSelectorOptions
 ---
 
-# Interface: UseSelectorOptions\<TSelected\>
-
 Defined in: [vue-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/vue-store/src/useSelector.ts#L4)
 
 ## Type Parameters

--- a/docs/reference/classes/ReadonlyStore.md
+++ b/docs/reference/classes/ReadonlyStore.md
@@ -3,6 +3,8 @@ id: ReadonlyStore
 title: ReadonlyStore
 ---
 
+# Class: ReadonlyStore\<T\>
+
 Defined in: [store.ts:59](https://github.com/TanStack/store/blob/main/packages/store/src/store.ts#L59)
 
 ## Type Parameters

--- a/docs/reference/classes/ReadonlyStore.md
+++ b/docs/reference/classes/ReadonlyStore.md
@@ -3,8 +3,6 @@ id: ReadonlyStore
 title: ReadonlyStore
 ---
 
-# Class: ReadonlyStore\<T\>
-
 Defined in: [store.ts:59](https://github.com/TanStack/store/blob/main/packages/store/src/store.ts#L59)
 
 ## Type Parameters

--- a/docs/reference/classes/Store.md
+++ b/docs/reference/classes/Store.md
@@ -3,8 +3,6 @@ id: Store
 title: Store
 ---
 
-# Class: Store\<T, TActions\>
-
 Defined in: [store.ts:15](https://github.com/TanStack/store/blob/main/packages/store/src/store.ts#L15)
 
 ## Type Parameters

--- a/docs/reference/classes/Store.md
+++ b/docs/reference/classes/Store.md
@@ -3,6 +3,8 @@ id: Store
 title: Store
 ---
 
+# Class: Store\<T, TActions\>
+
 Defined in: [store.ts:15](https://github.com/TanStack/store/blob/main/packages/store/src/store.ts#L15)
 
 ## Type Parameters

--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -3,6 +3,8 @@ id: batch
 title: batch
 ---
 
+# Function: batch()
+
 ```ts
 function batch(fn): void;
 ```

--- a/docs/reference/functions/batch.md
+++ b/docs/reference/functions/batch.md
@@ -3,8 +3,6 @@ id: batch
 title: batch
 ---
 
-# Function: batch()
-
 ```ts
 function batch(fn): void;
 ```

--- a/docs/reference/functions/createAsyncAtom.md
+++ b/docs/reference/functions/createAsyncAtom.md
@@ -3,6 +3,8 @@ id: createAsyncAtom
 title: createAsyncAtom
 ---
 
+# Function: createAsyncAtom()
+
 ```ts
 function createAsyncAtom<T>(getValue, options?): ReadonlyAtom<AsyncAtomState<T, unknown>>;
 ```

--- a/docs/reference/functions/createAsyncAtom.md
+++ b/docs/reference/functions/createAsyncAtom.md
@@ -3,8 +3,6 @@ id: createAsyncAtom
 title: createAsyncAtom
 ---
 
-# Function: createAsyncAtom()
-
 ```ts
 function createAsyncAtom<T>(getValue, options?): ReadonlyAtom<AsyncAtomState<T, unknown>>;
 ```

--- a/docs/reference/functions/createAtom.md
+++ b/docs/reference/functions/createAtom.md
@@ -3,8 +3,6 @@ id: createAtom
 title: createAtom
 ---
 
-# Function: createAtom()
-
 ## Call Signature
 
 ```ts

--- a/docs/reference/functions/createAtom.md
+++ b/docs/reference/functions/createAtom.md
@@ -3,6 +3,8 @@ id: createAtom
 title: createAtom
 ---
 
+# Function: createAtom()
+
 ## Call Signature
 
 ```ts

--- a/docs/reference/functions/createStore.md
+++ b/docs/reference/functions/createStore.md
@@ -3,6 +3,8 @@ id: createStore
 title: createStore
 ---
 
+# Function: createStore()
+
 ## Call Signature
 
 ```ts

--- a/docs/reference/functions/createStore.md
+++ b/docs/reference/functions/createStore.md
@@ -3,8 +3,6 @@ id: createStore
 title: createStore
 ---
 
-# Function: createStore()
-
 ## Call Signature
 
 ```ts

--- a/docs/reference/functions/flush.md
+++ b/docs/reference/functions/flush.md
@@ -3,8 +3,6 @@ id: flush
 title: flush
 ---
 
-# Function: flush()
-
 ```ts
 function flush(): void;
 ```

--- a/docs/reference/functions/flush.md
+++ b/docs/reference/functions/flush.md
@@ -3,6 +3,8 @@ id: flush
 title: flush
 ---
 
+# Function: flush()
+
 ```ts
 function flush(): void;
 ```

--- a/docs/reference/functions/shallow.md
+++ b/docs/reference/functions/shallow.md
@@ -3,6 +3,8 @@ id: shallow
 title: shallow
 ---
 
+# Function: shallow()
+
 ```ts
 function shallow<T>(objA, objB): boolean;
 ```

--- a/docs/reference/functions/shallow.md
+++ b/docs/reference/functions/shallow.md
@@ -3,8 +3,6 @@ id: shallow
 title: shallow
 ---
 
-# Function: shallow()
-
 ```ts
 function shallow<T>(objA, objB): boolean;
 ```

--- a/docs/reference/functions/toObserver.md
+++ b/docs/reference/functions/toObserver.md
@@ -3,6 +3,8 @@ id: toObserver
 title: toObserver
 ---
 
+# Function: toObserver()
+
 ```ts
 function toObserver<T>(
    nextHandler?, 

--- a/docs/reference/functions/toObserver.md
+++ b/docs/reference/functions/toObserver.md
@@ -3,8 +3,6 @@ id: toObserver
 title: toObserver
 ---
 
-# Function: toObserver()
-
 ```ts
 function toObserver<T>(
    nextHandler?, 

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,8 +3,6 @@ id: "@tanstack/store"
 title: "@tanstack/store"
 ---
 
-# @tanstack/store
-
 ## Classes
 
 - [ReadonlyStore](classes/ReadonlyStore.md)

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -3,6 +3,8 @@ id: "@tanstack/store"
 title: "@tanstack/store"
 ---
 
+# @tanstack/store
+
 ## Classes
 
 - [ReadonlyStore](classes/ReadonlyStore.md)

--- a/docs/reference/interfaces/Atom.md
+++ b/docs/reference/interfaces/Atom.md
@@ -3,6 +3,8 @@ id: Atom
 title: Atom
 ---
 
+# Interface: Atom\<T\>
+
 Defined in: [types.ts:42](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L42)
 
 ## Extends

--- a/docs/reference/interfaces/Atom.md
+++ b/docs/reference/interfaces/Atom.md
@@ -3,8 +3,6 @@ id: Atom
 title: Atom
 ---
 
-# Interface: Atom\<T\>
-
 Defined in: [types.ts:42](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L42)
 
 ## Extends

--- a/docs/reference/interfaces/AtomOptions.md
+++ b/docs/reference/interfaces/AtomOptions.md
@@ -3,6 +3,8 @@ id: AtomOptions
 title: AtomOptions
 ---
 
+# Interface: AtomOptions\<T\>
+
 Defined in: [types.ts:47](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L47)
 
 ## Type Parameters

--- a/docs/reference/interfaces/AtomOptions.md
+++ b/docs/reference/interfaces/AtomOptions.md
@@ -3,8 +3,6 @@ id: AtomOptions
 title: AtomOptions
 ---
 
-# Interface: AtomOptions\<T\>
-
 Defined in: [types.ts:47](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L47)
 
 ## Type Parameters

--- a/docs/reference/interfaces/BaseAtom.md
+++ b/docs/reference/interfaces/BaseAtom.md
@@ -3,6 +3,8 @@ id: BaseAtom
 title: BaseAtom
 ---
 
+# Interface: BaseAtom\<T\>
+
 Defined in: [types.ts:33](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L33)
 
 ## Extends

--- a/docs/reference/interfaces/BaseAtom.md
+++ b/docs/reference/interfaces/BaseAtom.md
@@ -3,8 +3,6 @@ id: BaseAtom
 title: BaseAtom
 ---
 
-# Interface: BaseAtom\<T\>
-
 Defined in: [types.ts:33](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L33)
 
 ## Extends

--- a/docs/reference/interfaces/InternalBaseAtom.md
+++ b/docs/reference/interfaces/InternalBaseAtom.md
@@ -3,6 +3,8 @@ id: InternalBaseAtom
 title: InternalBaseAtom
 ---
 
+# Interface: InternalBaseAtom\<T\>
+
 Defined in: [types.ts:35](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L35)
 
 ## Extends

--- a/docs/reference/interfaces/InternalBaseAtom.md
+++ b/docs/reference/interfaces/InternalBaseAtom.md
@@ -3,8 +3,6 @@ id: InternalBaseAtom
 title: InternalBaseAtom
 ---
 
-# Interface: InternalBaseAtom\<T\>
-
 Defined in: [types.ts:35](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L35)
 
 ## Extends

--- a/docs/reference/interfaces/InternalReadonlyAtom.md
+++ b/docs/reference/interfaces/InternalReadonlyAtom.md
@@ -3,8 +3,6 @@ id: InternalReadonlyAtom
 title: InternalReadonlyAtom
 ---
 
-# Interface: InternalReadonlyAtom\<T\>
-
 Defined in: [types.ts:53](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L53)
 
 ## Extends

--- a/docs/reference/interfaces/InternalReadonlyAtom.md
+++ b/docs/reference/interfaces/InternalReadonlyAtom.md
@@ -3,6 +3,8 @@ id: InternalReadonlyAtom
 title: InternalReadonlyAtom
 ---
 
+# Interface: InternalReadonlyAtom\<T\>
+
 Defined in: [types.ts:53](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L53)
 
 ## Extends

--- a/docs/reference/interfaces/InteropSubscribable.md
+++ b/docs/reference/interfaces/InteropSubscribable.md
@@ -3,8 +3,6 @@ id: InteropSubscribable
 title: InteropSubscribable
 ---
 
-# Interface: InteropSubscribable\<T\>
-
 Defined in: [types.ts:5](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L5)
 
 ## Extended by

--- a/docs/reference/interfaces/InteropSubscribable.md
+++ b/docs/reference/interfaces/InteropSubscribable.md
@@ -3,6 +3,8 @@ id: InteropSubscribable
 title: InteropSubscribable
 ---
 
+# Interface: InteropSubscribable\<T\>
+
 Defined in: [types.ts:5](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L5)
 
 ## Extended by

--- a/docs/reference/interfaces/Readable.md
+++ b/docs/reference/interfaces/Readable.md
@@ -3,6 +3,8 @@ id: Readable
 title: Readable
 ---
 
+# Interface: Readable\<T\>
+
 Defined in: [types.ts:29](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L29)
 
 ## Extends

--- a/docs/reference/interfaces/Readable.md
+++ b/docs/reference/interfaces/Readable.md
@@ -3,8 +3,6 @@ id: Readable
 title: Readable
 ---
 
-# Interface: Readable\<T\>
-
 Defined in: [types.ts:29](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L29)
 
 ## Extends

--- a/docs/reference/interfaces/ReadonlyAtom.md
+++ b/docs/reference/interfaces/ReadonlyAtom.md
@@ -3,6 +3,8 @@ id: ReadonlyAtom
 title: ReadonlyAtom
 ---
 
+# Interface: ReadonlyAtom\<T\>
+
 Defined in: [types.ts:67](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L67)
 
 An atom that is read-only and cannot be set.

--- a/docs/reference/interfaces/ReadonlyAtom.md
+++ b/docs/reference/interfaces/ReadonlyAtom.md
@@ -3,8 +3,6 @@ id: ReadonlyAtom
 title: ReadonlyAtom
 ---
 
-# Interface: ReadonlyAtom\<T\>
-
 Defined in: [types.ts:67](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L67)
 
 An atom that is read-only and cannot be set.

--- a/docs/reference/interfaces/Subscribable.md
+++ b/docs/reference/interfaces/Subscribable.md
@@ -3,8 +3,6 @@ id: Subscribable
 title: Subscribable
 ---
 
-# Interface: Subscribable\<T\>
-
 Defined in: [types.ts:20](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L20)
 
 ## Extends

--- a/docs/reference/interfaces/Subscribable.md
+++ b/docs/reference/interfaces/Subscribable.md
@@ -3,6 +3,8 @@ id: Subscribable
 title: Subscribable
 ---
 
+# Interface: Subscribable\<T\>
+
 Defined in: [types.ts:20](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L20)
 
 ## Extends

--- a/docs/reference/interfaces/Subscription.md
+++ b/docs/reference/interfaces/Subscription.md
@@ -3,8 +3,6 @@ id: Subscription
 title: Subscription
 ---
 
-# Interface: Subscription
-
 Defined in: [types.ts:16](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L16)
 
 ## Properties

--- a/docs/reference/interfaces/Subscription.md
+++ b/docs/reference/interfaces/Subscription.md
@@ -3,6 +3,8 @@ id: Subscription
 title: Subscription
 ---
 
+# Interface: Subscription
+
 Defined in: [types.ts:16](https://github.com/TanStack/store/blob/main/packages/store/src/types.ts#L16)
 
 ## Properties

--- a/docs/reference/type-aliases/AnyAtom.md
+++ b/docs/reference/type-aliases/AnyAtom.md
@@ -3,6 +3,8 @@ id: AnyAtom
 title: AnyAtom
 ---
 
+# Type Alias: AnyAtom
+
 ```ts
 type AnyAtom = BaseAtom<any>;
 ```

--- a/docs/reference/type-aliases/AnyAtom.md
+++ b/docs/reference/type-aliases/AnyAtom.md
@@ -3,8 +3,6 @@ id: AnyAtom
 title: AnyAtom
 ---
 
-# Type Alias: AnyAtom
-
 ```ts
 type AnyAtom = BaseAtom<any>;
 ```

--- a/docs/reference/type-aliases/Observer.md
+++ b/docs/reference/type-aliases/Observer.md
@@ -3,8 +3,6 @@ id: Observer
 title: Observer
 ---
 
-# Type Alias: Observer\<T\>
-
 ```ts
 type Observer<T> = object;
 ```

--- a/docs/reference/type-aliases/Observer.md
+++ b/docs/reference/type-aliases/Observer.md
@@ -3,6 +3,8 @@ id: Observer
 title: Observer
 ---
 
+# Type Alias: Observer\<T\>
+
 ```ts
 type Observer<T> = object;
 ```

--- a/docs/reference/type-aliases/Selection.md
+++ b/docs/reference/type-aliases/Selection.md
@@ -3,6 +3,8 @@ id: Selection
 title: Selection
 ---
 
+# Type Alias: Selection\<TSelected\>
+
 ```ts
 type Selection<TSelected> = Readable<TSelected>;
 ```

--- a/docs/reference/type-aliases/Selection.md
+++ b/docs/reference/type-aliases/Selection.md
@@ -3,8 +3,6 @@ id: Selection
 title: Selection
 ---
 
-# Type Alias: Selection\<TSelected\>
-
 ```ts
 type Selection<TSelected> = Readable<TSelected>;
 ```

--- a/docs/reference/type-aliases/StoreAction.md
+++ b/docs/reference/type-aliases/StoreAction.md
@@ -3,6 +3,8 @@ id: StoreAction
 title: StoreAction
 ---
 
+# Type Alias: StoreAction()
+
 ```ts
 type StoreAction = (...args) => any;
 ```

--- a/docs/reference/type-aliases/StoreAction.md
+++ b/docs/reference/type-aliases/StoreAction.md
@@ -3,8 +3,6 @@ id: StoreAction
 title: StoreAction
 ---
 
-# Type Alias: StoreAction()
-
 ```ts
 type StoreAction = (...args) => any;
 ```

--- a/docs/reference/type-aliases/StoreActionMap.md
+++ b/docs/reference/type-aliases/StoreActionMap.md
@@ -3,8 +3,6 @@ id: StoreActionMap
 title: StoreActionMap
 ---
 
-# Type Alias: StoreActionMap
-
 ```ts
 type StoreActionMap = Record<string, StoreAction>;
 ```

--- a/docs/reference/type-aliases/StoreActionMap.md
+++ b/docs/reference/type-aliases/StoreActionMap.md
@@ -3,6 +3,8 @@ id: StoreActionMap
 title: StoreActionMap
 ---
 
+# Type Alias: StoreActionMap
+
 ```ts
 type StoreActionMap = Record<string, StoreAction>;
 ```

--- a/docs/reference/type-aliases/StoreActionsFactory.md
+++ b/docs/reference/type-aliases/StoreActionsFactory.md
@@ -3,8 +3,6 @@ id: StoreActionsFactory
 title: StoreActionsFactory
 ---
 
-# Type Alias: StoreActionsFactory()\<T, TActions\>
-
 ```ts
 type StoreActionsFactory<T, TActions> = (store) => TActions;
 ```

--- a/docs/reference/type-aliases/StoreActionsFactory.md
+++ b/docs/reference/type-aliases/StoreActionsFactory.md
@@ -3,6 +3,8 @@ id: StoreActionsFactory
 title: StoreActionsFactory
 ---
 
+# Type Alias: StoreActionsFactory()\<T, TActions\>
+
 ```ts
 type StoreActionsFactory<T, TActions> = (store) => TActions;
 ```

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,0 +1,3 @@
+{
+  "hidePageTitle": true
+}


### PR DESCRIPTION
## 🎯 Changes

Configure TypeDoc to omit page titles because tanstack.com renders the title from frontmatter.


## ✅ Checklist

- [ ] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).

## 🚀 Release Impact

- [ ] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md).
- [x] This change is docs/CI/dev-only (no release).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed redundant generated title headings from API reference pages across supported frameworks and core store documentation.
  - Standardized reference pages to begin with frontmatter followed by signatures, sections, or source details.
  - Existing API signatures, descriptions, examples, and deprecation guidance remain unchanged.
  - Updated documentation generation settings to hide default page titles in future TypeDoc output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->