### PR TITLE
feat(react-store)!: build useSelector on React's useSyncExternalStore with one selection ref, require React 18+

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,21 @@
+{
+  "mode": "pre",
+  "tag": "alpha",
+  "initialVersions": {
+    "@tanstack/store-example-svelte-atoms": "0.0.0",
+    "@tanstack/store-example-svelte-simple": "0.0.0",
+    "@tanstack/store-example-svelte-store-actions": "0.0.0",
+    "@tanstack/store-example-svelte-store-context": "0.0.0",
+    "@tanstack/store-example-svelte-stores": "0.0.0",
+    "@tanstack/angular-store": "0.11.1",
+    "@tanstack/lit-store": "0.14.1",
+    "@tanstack/octane-store": "0.12.2",
+    "@tanstack/preact-store": "0.13.2",
+    "@tanstack/react-store": "0.11.1",
+    "@tanstack/solid-store": "0.11.1",
+    "@tanstack/store": "0.11.1",
+    "@tanstack/svelte-store": "0.12.1",
+    "@tanstack/vue-store": "0.11.1"
+  },
+  "changesets": []
+}

--- a/.changeset/react-store-use-selector-single-ref.md
+++ b/.changeset/react-store-use-selector-single-ref.md
@@ -1,5 +1,7 @@
 ---
-'@tanstack/react-store': patch
+'@tanstack/react-store': major
 ---
 
-`useSelector` now builds on `useSyncExternalStore` directly with a single memoized selection ref instead of the `use-sync-external-store/shim/with-selector` helper: fewer hook slots and allocations per subscribed component, no per-component passive effect, and the `with-selector` module leaves consumer bundles. Public API and semantics are unchanged.
+`@tanstack/react-store` now requires React 18 or newer (`peerDependencies` are `react` and `react-dom` `^18.0.0 || ^19.0.0`); support for React 16.8 and 17 has been dropped.
+
+`useSelector` builds on React's built-in `useSyncExternalStore` with a single memoized selection ref instead of the `use-sync-external-store/shim/with-selector` helper: fewer hook slots and allocations per subscribed component, no per-component passive effect, and the `use-sync-external-store` dependency is gone from consumer bundles. The public API and selection semantics of `useSelector`, `useAtom`, `_useStore` and `useStore` are unchanged.

--- a/.changeset/react-store-use-selector-single-ref.md
+++ b/.changeset/react-store-use-selector-single-ref.md
@@ -1,0 +1,5 @@
+---
+'@tanstack/react-store': patch
+---
+
+`useSelector` now builds on `useSyncExternalStore` directly with a single memoized selection ref instead of the `use-sync-external-store/shim/with-selector` helper: fewer hook slots and allocations per subscribed component, no per-component passive effect, and the `with-selector` module leaves consumer bundles. Public API and semantics are unchanged.

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -12,7 +12,7 @@ function useSelector<TSource, TSelected>(
    options?): TSelected;
 ```
 
-Defined in: [packages/react-store/src/useSelector.ts:52](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L52)
+Defined in: [packages/react-store/src/useSelector.ts:140](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L140)
 
 Selects a slice of state from an atom or store and subscribes the component
 to that selection.
@@ -41,7 +41,7 @@ Omit the selector to subscribe to the whole value.
 
 ### selector
 
-(`snapshot`) => `TSelected`
+`Selector`\<`TSource`, `TSelected`\> = `identity`
 
 ### options?
 

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -12,7 +12,7 @@ function useSelector<TSource, TSelected>(
    options?): TSelected;
 ```
 
-Defined in: [packages/react-store/src/useSelector.ts:43](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L43)
+Defined in: [packages/react-store/src/useSelector.ts:53](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L53)
 
 Selects a slice of state from an atom or store and subscribes the component
 to that selection.

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -12,7 +12,7 @@ function useSelector<TSource, TSelected>(
    options?): TSelected;
 ```
 
-Defined in: [packages/react-store/src/useSelector.ts:53](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L53)
+Defined in: [packages/react-store/src/useSelector.ts:52](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L52)
 
 Selects a slice of state from an atom or store and subscribes the component
 to that selection.

--- a/docs/framework/react/reference/functions/useSelector.md
+++ b/docs/framework/react/reference/functions/useSelector.md
@@ -12,7 +12,7 @@ function useSelector<TSource, TSelected>(
    options?): TSelected;
 ```
 
-Defined in: [packages/react-store/src/useSelector.ts:140](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L140)
+Defined in: [packages/react-store/src/useSelector.ts:58](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L58)
 
 Selects a slice of state from an atom or store and subscribes the component
 to that selection.
@@ -41,7 +41,7 @@ Omit the selector to subscribe to the whole value.
 
 ### selector
 
-`Selector`\<`TSource`, `TSelected`\> = `identity`
+(`snapshot`) => `TSelected`
 
 ### options?
 

--- a/docs/framework/react/reference/interfaces/UseSelectorOptions.md
+++ b/docs/framework/react/reference/interfaces/UseSelectorOptions.md
@@ -5,7 +5,7 @@ title: UseSelectorOptions
 
 # Interface: UseSelectorOptions\<TSelected\>
 
-Defined in: [packages/react-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L4)
+Defined in: [packages/react-store/src/useSelector.ts:3](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L3)
 
 ## Type Parameters
 
@@ -21,7 +21,7 @@ Defined in: [packages/react-store/src/useSelector.ts:4](https://github.com/TanSt
 optional compare: (a, b) => boolean;
 ```
 
-Defined in: [packages/react-store/src/useSelector.ts:5](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L5)
+Defined in: [packages/react-store/src/useSelector.ts:4](https://github.com/TanStack/store/blob/main/packages/react-store/src/useSelector.ts#L4)
 
 #### Parameters
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ You can install TanStack Store with any [NPM](https://npmjs.com) package manager
 npm install @tanstack/react-store
 ```
 
-TanStack Store is compatible with React v16.8+ and is currently only compatible with ReactDOM only. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).
+TanStack Store is compatible with React v18+ and is currently only compatible with ReactDOM only. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).
 
 ## Preact
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ You can install TanStack Store with any [NPM](https://npmjs.com) package manager
 npm install @tanstack/react-store
 ```
 
-TanStack Store is compatible with React v18+ and is currently only compatible with ReactDOM only. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).
+TanStack Store is compatible with React v18+ and currently supports ReactDOM only. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).
 
 ## Preact
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -11,7 +11,7 @@ You can install TanStack Store with any [NPM](https://npmjs.com) package manager
 npm install @tanstack/react-store
 ```
 
-TanStack Store is compatible with React v18+ and currently supports ReactDOM only. If you would like to contribute to the React Native adapter, please reach out to us on [Discord](https://tlinz.com/discord).
+TanStack Store is compatible with React v18+.
 
 ## Preact
 

--- a/packages/react-store/package.json
+++ b/packages/react-store/package.json
@@ -49,20 +49,18 @@
     "src"
   ],
   "dependencies": {
-    "@tanstack/store": "workspace:*",
-    "use-sync-external-store": "^1.6.0"
+    "@tanstack/store": "workspace:*"
   },
   "devDependencies": {
     "@testing-library/react": "^16.3.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@types/use-sync-external-store": "^1.5.0",
     "@vitejs/plugin-react": "^6.0.1",
     "react": "^19.2.5",
     "react-dom": "^19.2.5"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
-    "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+    "react": "^18.0.0 || ^19.0.0",
+    "react-dom": "^18.0.0 || ^19.0.0"
   }
 }

--- a/packages/react-store/src/useSelector.ts
+++ b/packages/react-store/src/useSelector.ts
@@ -1,19 +1,29 @@
-import { useCallback } from 'react'
-import { useSyncExternalStoreWithSelector } from 'use-sync-external-store/shim/with-selector'
+import { useCallback, useRef } from 'react'
+import { useSyncExternalStore } from 'use-sync-external-store/shim'
 
 export interface UseSelectorOptions<TSelected> {
   compare?: (a: TSelected, b: TSelected) => boolean
 }
-
-type SyncExternalStoreSubscribe = Parameters<
-  typeof useSyncExternalStoreWithSelector
->[0]
 
 type SelectionSource<T> = {
   get: () => T
   subscribe: (listener: (value: T) => void) => {
     unsubscribe: () => void
   }
+}
+
+/**
+ * The last selection computed for a component, keyed on the selector and the
+ * source snapshot that produced it.
+ */
+type Selection<TSource, TSelected> = {
+  selector: (snapshot: TSource) => TSelected
+  snapshot: TSource
+  selected: TSelected
+}
+
+function identity<TSource, TSelected>(snapshot: TSource): TSelected {
+  return snapshot as unknown as TSelected
 }
 
 function defaultCompare<T>(a: T, b: T) {
@@ -42,26 +52,62 @@ function defaultCompare<T>(a: T, b: T) {
  */
 export function useSelector<TSource, TSelected = NoInfer<TSource>>(
   source: SelectionSource<TSource>,
-  selector: (snapshot: TSource) => TSelected = (s) => s as unknown as TSelected,
+  selector: (snapshot: TSource) => TSelected = identity,
   options?: UseSelectorOptions<TSelected>,
 ): TSelected {
   const compare = options?.compare ?? defaultCompare
 
-  const subscribe: SyncExternalStoreSubscribe = useCallback(
-    (handleStoreChange) => {
-      const { unsubscribe } = source.subscribe(handleStoreChange)
-      return unsubscribe
-    },
+  // `useSyncExternalStore` re-subscribes in a passive effect whenever
+  // `subscribe` changes identity, so it is the one callback worth memoizing.
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => source.subscribe(onStoreChange).unsubscribe,
     [source],
   )
 
-  const getSnapshot = useCallback(() => source.get(), [source])
+  const selectionRef = useRef<Selection<TSource, TSelected> | null>(null)
 
-  return useSyncExternalStoreWithSelector(
-    subscribe,
-    getSnapshot,
-    getSnapshot,
-    selector,
-    compare,
-  )
+  // `getSnapshot` is a plain closure: it must read this render's `selector` and
+  // `compare`, which are usually inline and would defeat a `useCallback`
+  // anyway. React only compares it to decide whether to re-check the store
+  // after commit, so a fresh identity per render is cheap.
+  //
+  // The memo is keyed on the selector identity as well as the snapshot so that
+  // a render that suspends with a different selector cannot poison the
+  // selection of the committed selector, which stays subscribed meanwhile.
+  const getSnapshot = () => {
+    const snapshot = source.get()
+    const cached = selectionRef.current
+
+    if (
+      cached !== null &&
+      cached.selector === selector &&
+      cached.snapshot === snapshot
+    ) {
+      return cached.selected
+    }
+
+    const selected = selector(snapshot)
+
+    if (cached === null) {
+      selectionRef.current = { selector, snapshot, selected }
+      return selected
+    }
+
+    cached.selector = selector
+    cached.snapshot = snapshot
+
+    // Keep the previous selection's identity when `compare` considers the new
+    // one equal so that `useSyncExternalStore` does not re-render the component.
+    // Like `useSyncExternalStoreWithSelector`, this compares against the
+    // previous selection even when the selector identity changed: inline
+    // selectors are recreated on every render and must still return the same
+    // object when the selection is equal.
+    if (!compare(cached.selected, selected)) {
+      cached.selected = selected
+    }
+
+    return cached.selected
+  }
+
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
 }

--- a/packages/react-store/src/useSelector.ts
+++ b/packages/react-store/src/useSelector.ts
@@ -58,8 +58,16 @@ export function useSelector<TSource, TSelected = NoInfer<TSource>>(
 
   // `useSyncExternalStore` re-subscribes in a passive effect whenever
   // `subscribe` changes identity, so it is the one callback worth memoizing.
+  // The cleanup calls `unsubscribe` on the subscription object so that sources
+  // whose `unsubscribe` relies on `this` keep working.
   const subscribe = useCallback(
-    (onStoreChange: () => void) => source.subscribe(onStoreChange).unsubscribe,
+    (onStoreChange: () => void) => {
+      const subscription = source.subscribe(onStoreChange)
+
+      return () => {
+        subscription.unsubscribe()
+      }
+    },
     [source],
   )
 

--- a/packages/react-store/src/useSelector.ts
+++ b/packages/react-store/src/useSelector.ts
@@ -1,5 +1,4 @@
-import { useCallback, useRef } from 'react'
-import { useSyncExternalStore } from 'use-sync-external-store/shim'
+import { useCallback, useRef, useSyncExternalStore } from 'react'
 
 export interface UseSelectorOptions<TSelected> {
   compare?: (a: TSelected, b: TSelected) => boolean
@@ -98,10 +97,10 @@ export function useSelector<TSource, TSelected = NoInfer<TSource>>(
 
     // Keep the previous selection's identity when `compare` considers the new
     // one equal so that `useSyncExternalStore` does not re-render the component.
-    // Like `useSyncExternalStoreWithSelector`, this compares against the
-    // previous selection even when the selector identity changed: inline
-    // selectors are recreated on every render and must still return the same
-    // object when the selection is equal.
+    // Like the former `use-sync-external-store/shim/with-selector` helper, this
+    // compares against the previous selection even when the selector identity
+    // changed: inline selectors are recreated on every render and must still
+    // return the same object when the selection is equal.
     if (!compare(cached.selected, selected)) {
       cached.selected = selected
     }

--- a/packages/react-store/src/useSelector.ts
+++ b/packages/react-store/src/useSelector.ts
@@ -11,33 +11,20 @@ type SelectionSource<T> = {
   }
 }
 
-type Selector<TSource, TSelected> = (snapshot: TSource) => TSelected
-
-type Compare<TSelected> = (a: TSelected, b: TSelected) => boolean
-
 /**
- * The last selection computed for a component, keyed on the selector, the
- * compare function and the source snapshot that produced it.
- */
-type Selection<TSource, TSelected> = {
-  selector: Selector<TSource, TSelected>
-  compare: Compare<TSelected>
-  snapshot: TSource
-  selected: TSelected
-}
-
-/**
- * The callbacks handed to `useSyncExternalStore` together with the inputs they
- * were built for. The selection record is mutated in place and carried over,
- * so every instance of a component shares it.
+ * Per-component state, mutated in place. The inputs and the callbacks built
+ * for them are written during render; the selection is written by whichever
+ * `getSnapshot` closure computed it last and is keyed on that closure.
  */
 type Instance<TSource, TSelected> = {
-  source: SelectionSource<TSource>
-  selector: Selector<TSource, TSelected>
-  compare: Compare<TSelected>
-  subscribe: (onStoreChange: () => void) => () => void
-  getSnapshot: () => TSelected
-  selection: Selection<TSource, TSelected> | null
+  source?: SelectionSource<TSource>
+  selector?: (snapshot: TSource) => TSelected
+  compare?: (a: TSelected, b: TSelected) => boolean
+  subscribe?: (onStoreChange: () => void) => () => void
+  getSnapshot?: () => TSelected
+  owner: (() => TSelected) | null
+  snapshot?: TSource
+  selected?: TSelected
 }
 
 function identity<TSource, TSelected>(snapshot: TSource): TSelected {
@@ -46,75 +33,6 @@ function identity<TSource, TSelected>(snapshot: TSource): TSelected {
 
 function defaultCompare<T>(a: T, b: T) {
   return a === b
-}
-
-function createInstance<TSource, TSelected>(
-  source: SelectionSource<TSource>,
-  selector: Selector<TSource, TSelected>,
-  compare: Compare<TSelected>,
-  previous: Instance<TSource, TSelected> | null,
-): Instance<TSource, TSelected> {
-  const instance: Instance<TSource, TSelected> = {
-    source,
-    selector,
-    compare,
-    selection: previous === null ? null : previous.selection,
-    // `useSyncExternalStore` re-subscribes whenever `subscribe` changes
-    // identity, so it is only replaced when the source changes.
-    subscribe:
-      previous?.source === source
-        ? previous.subscribe
-        : (onStoreChange) => {
-            const subscription = source.subscribe(onStoreChange)
-
-            // Call `unsubscribe` on the subscription so sources that rely on
-            // `this` keep working.
-            return () => subscription.unsubscribe()
-          },
-    // The closure captures its inputs instead of reading them from the ref so
-    // that a render which suspends with a different selector cannot change
-    // what the committed subscription selects. The shared selection record is
-    // keyed on the selector and compare identities for the same reason.
-    getSnapshot: () => {
-      const snapshot = source.get()
-      const cached = instance.selection
-
-      if (
-        cached !== null &&
-        cached.selector === selector &&
-        cached.compare === compare &&
-        cached.snapshot === snapshot
-      ) {
-        return cached.selected
-      }
-
-      const selected = selector(snapshot)
-
-      if (cached === null) {
-        instance.selection = { selector, compare, snapshot, selected }
-        return selected
-      }
-
-      cached.selector = selector
-      cached.compare = compare
-      cached.snapshot = snapshot
-
-      // Keep the previous selection's identity when `compare` considers the
-      // new one equal so that `useSyncExternalStore` does not re-render the
-      // component. Like the former `use-sync-external-store/shim/with-selector`
-      // helper, this compares against the previous selection even when the
-      // selector identity changed: inline selectors are recreated on every
-      // render and must still return the same object when the selection is
-      // equal.
-      if (!compare(cached.selected, selected)) {
-        cached.selected = selected
-      }
-
-      return cached.selected
-    },
-  }
-
-  return instance
 }
 
 /**
@@ -139,35 +57,77 @@ function createInstance<TSource, TSelected>(
  */
 export function useSelector<TSource, TSelected = NoInfer<TSource>>(
   source: SelectionSource<TSource>,
-  selector: Selector<TSource, TSelected> = identity,
+  selector: (snapshot: TSource) => TSelected = identity,
   options?: UseSelectorOptions<TSelected>,
 ): TSelected {
   const compare = options?.compare ?? defaultCompare
 
-  // One ref instead of `useCallback`s: React schedules a passive effect and a
-  // consistency check whenever `getSnapshot` changes identity, so it is only
-  // rebuilt when its inputs change. With a stable selector, a re-render that
-  // leaves the store untouched costs no allocations and no effects.
+  // One ref instead of `useCallback`s. `useSyncExternalStore` re-subscribes
+  // whenever `subscribe` changes identity and schedules a passive effect plus
+  // a consistency check whenever `getSnapshot` does, so both are only rebuilt
+  // when their inputs change. With a stable selector, a re-render that leaves
+  // the store untouched costs no allocations and no effects.
   const instanceRef = useRef<Instance<TSource, TSelected> | null>(null)
-  let instance = instanceRef.current
+  const instance =
+    instanceRef.current ?? (instanceRef.current = { owner: null })
+  const sourceChanged = instance.source !== source
+
+  if (sourceChanged) {
+    instance.subscribe = (onStoreChange) => {
+      const subscription = source.subscribe(onStoreChange)
+
+      // Call `unsubscribe` on the subscription so sources that rely on `this`
+      // keep working.
+      return () => subscription.unsubscribe()
+    }
+  }
 
   if (
-    instance === null ||
-    instance.source !== source ||
+    sourceChanged ||
     instance.selector !== selector ||
     instance.compare !== compare
   ) {
-    instance = instanceRef.current = createInstance(
-      source,
-      selector,
-      compare,
-      instance,
-    )
+    instance.source = source
+    instance.selector = selector
+    instance.compare = compare
+
+    // The closure captures its inputs instead of reading them from the
+    // instance so that a render which suspends with a different selector
+    // cannot change what the committed subscription selects. The selection is
+    // keyed on the closure for the same reason.
+    const getSnapshot = () => {
+      const snapshot = source.get()
+
+      if (instance.owner !== getSnapshot || instance.snapshot !== snapshot) {
+        const selected = selector(snapshot)
+
+        // Keep the previous selection's identity when `compare` considers the
+        // new one equal so that `useSyncExternalStore` does not re-render the
+        // component. Like the former `use-sync-external-store/shim/with-selector`
+        // helper, this compares against the previous selection even when the
+        // selector identity changed: inline selectors are recreated on every
+        // render and must still return the same object when the selection is
+        // equal.
+        if (
+          instance.owner === null ||
+          !compare(instance.selected as TSelected, selected)
+        ) {
+          instance.selected = selected
+        }
+
+        instance.owner = getSnapshot
+        instance.snapshot = snapshot
+      }
+
+      return instance.selected as TSelected
+    }
+
+    instance.getSnapshot = getSnapshot
   }
 
   return useSyncExternalStore(
-    instance.subscribe,
-    instance.getSnapshot,
+    instance.subscribe!,
+    instance.getSnapshot!,
     instance.getSnapshot,
   )
 }

--- a/packages/react-store/src/useSelector.ts
+++ b/packages/react-store/src/useSelector.ts
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useSyncExternalStore } from 'react'
+import { useRef, useSyncExternalStore } from 'react'
 
 export interface UseSelectorOptions<TSelected> {
   compare?: (a: TSelected, b: TSelected) => boolean
@@ -11,14 +11,33 @@ type SelectionSource<T> = {
   }
 }
 
+type Selector<TSource, TSelected> = (snapshot: TSource) => TSelected
+
+type Compare<TSelected> = (a: TSelected, b: TSelected) => boolean
+
 /**
- * The last selection computed for a component, keyed on the selector and the
- * source snapshot that produced it.
+ * The last selection computed for a component, keyed on the selector, the
+ * compare function and the source snapshot that produced it.
  */
 type Selection<TSource, TSelected> = {
-  selector: (snapshot: TSource) => TSelected
+  selector: Selector<TSource, TSelected>
+  compare: Compare<TSelected>
   snapshot: TSource
   selected: TSelected
+}
+
+/**
+ * The callbacks handed to `useSyncExternalStore` together with the inputs they
+ * were built for. The selection record is mutated in place and carried over,
+ * so every instance of a component shares it.
+ */
+type Instance<TSource, TSelected> = {
+  source: SelectionSource<TSource>
+  selector: Selector<TSource, TSelected>
+  compare: Compare<TSelected>
+  subscribe: (onStoreChange: () => void) => () => void
+  getSnapshot: () => TSelected
+  selection: Selection<TSource, TSelected> | null
 }
 
 function identity<TSource, TSelected>(snapshot: TSource): TSelected {
@@ -27,6 +46,75 @@ function identity<TSource, TSelected>(snapshot: TSource): TSelected {
 
 function defaultCompare<T>(a: T, b: T) {
   return a === b
+}
+
+function createInstance<TSource, TSelected>(
+  source: SelectionSource<TSource>,
+  selector: Selector<TSource, TSelected>,
+  compare: Compare<TSelected>,
+  previous: Instance<TSource, TSelected> | null,
+): Instance<TSource, TSelected> {
+  const instance: Instance<TSource, TSelected> = {
+    source,
+    selector,
+    compare,
+    selection: previous === null ? null : previous.selection,
+    // `useSyncExternalStore` re-subscribes whenever `subscribe` changes
+    // identity, so it is only replaced when the source changes.
+    subscribe:
+      previous?.source === source
+        ? previous.subscribe
+        : (onStoreChange) => {
+            const subscription = source.subscribe(onStoreChange)
+
+            // Call `unsubscribe` on the subscription so sources that rely on
+            // `this` keep working.
+            return () => subscription.unsubscribe()
+          },
+    // The closure captures its inputs instead of reading them from the ref so
+    // that a render which suspends with a different selector cannot change
+    // what the committed subscription selects. The shared selection record is
+    // keyed on the selector and compare identities for the same reason.
+    getSnapshot: () => {
+      const snapshot = source.get()
+      const cached = instance.selection
+
+      if (
+        cached !== null &&
+        cached.selector === selector &&
+        cached.compare === compare &&
+        cached.snapshot === snapshot
+      ) {
+        return cached.selected
+      }
+
+      const selected = selector(snapshot)
+
+      if (cached === null) {
+        instance.selection = { selector, compare, snapshot, selected }
+        return selected
+      }
+
+      cached.selector = selector
+      cached.compare = compare
+      cached.snapshot = snapshot
+
+      // Keep the previous selection's identity when `compare` considers the
+      // new one equal so that `useSyncExternalStore` does not re-render the
+      // component. Like the former `use-sync-external-store/shim/with-selector`
+      // helper, this compares against the previous selection even when the
+      // selector identity changed: inline selectors are recreated on every
+      // render and must still return the same object when the selection is
+      // equal.
+      if (!compare(cached.selected, selected)) {
+        cached.selected = selected
+      }
+
+      return cached.selected
+    },
+  }
+
+  return instance
 }
 
 /**
@@ -51,70 +139,35 @@ function defaultCompare<T>(a: T, b: T) {
  */
 export function useSelector<TSource, TSelected = NoInfer<TSource>>(
   source: SelectionSource<TSource>,
-  selector: (snapshot: TSource) => TSelected = identity,
+  selector: Selector<TSource, TSelected> = identity,
   options?: UseSelectorOptions<TSelected>,
 ): TSelected {
   const compare = options?.compare ?? defaultCompare
 
-  // `useSyncExternalStore` re-subscribes in a passive effect whenever
-  // `subscribe` changes identity, so it is the one callback worth memoizing.
-  // The cleanup calls `unsubscribe` on the subscription object so that sources
-  // whose `unsubscribe` relies on `this` keep working.
-  const subscribe = useCallback(
-    (onStoreChange: () => void) => {
-      const subscription = source.subscribe(onStoreChange)
+  // One ref instead of `useCallback`s: React schedules a passive effect and a
+  // consistency check whenever `getSnapshot` changes identity, so it is only
+  // rebuilt when its inputs change. With a stable selector, a re-render that
+  // leaves the store untouched costs no allocations and no effects.
+  const instanceRef = useRef<Instance<TSource, TSelected> | null>(null)
+  let instance = instanceRef.current
 
-      return () => {
-        subscription.unsubscribe()
-      }
-    },
-    [source],
-  )
-
-  const selectionRef = useRef<Selection<TSource, TSelected> | null>(null)
-
-  // `getSnapshot` is a plain closure: it must read this render's `selector` and
-  // `compare`, which are usually inline and would defeat a `useCallback`
-  // anyway. React only compares it to decide whether to re-check the store
-  // after commit, so a fresh identity per render is cheap.
-  //
-  // The memo is keyed on the selector identity as well as the snapshot so that
-  // a render that suspends with a different selector cannot poison the
-  // selection of the committed selector, which stays subscribed meanwhile.
-  const getSnapshot = () => {
-    const snapshot = source.get()
-    const cached = selectionRef.current
-
-    if (
-      cached !== null &&
-      cached.selector === selector &&
-      cached.snapshot === snapshot
-    ) {
-      return cached.selected
-    }
-
-    const selected = selector(snapshot)
-
-    if (cached === null) {
-      selectionRef.current = { selector, snapshot, selected }
-      return selected
-    }
-
-    cached.selector = selector
-    cached.snapshot = snapshot
-
-    // Keep the previous selection's identity when `compare` considers the new
-    // one equal so that `useSyncExternalStore` does not re-render the component.
-    // Like the former `use-sync-external-store/shim/with-selector` helper, this
-    // compares against the previous selection even when the selector identity
-    // changed: inline selectors are recreated on every render and must still
-    // return the same object when the selection is equal.
-    if (!compare(cached.selected, selected)) {
-      cached.selected = selected
-    }
-
-    return cached.selected
+  if (
+    instance === null ||
+    instance.source !== source ||
+    instance.selector !== selector ||
+    instance.compare !== compare
+  ) {
+    instance = instanceRef.current = createInstance(
+      source,
+      selector,
+      compare,
+      instance,
+    )
   }
 
-  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+  return useSyncExternalStore(
+    instance.subscribe,
+    instance.getSnapshot,
+    instance.getSnapshot,
+  )
 }

--- a/packages/react-store/tests/index.test.tsx
+++ b/packages/react-store/tests/index.test.tsx
@@ -775,6 +775,47 @@ describe('useSelector selection memo', () => {
   })
 })
 
+describe('useSelector subscription cleanup', () => {
+  it('unsubscribes through the subscription object so `this`-based sources clean up', () => {
+    const listeners = new Set<(value: number) => void>()
+
+    class Subscription {
+      closed = false
+
+      constructor(private readonly listener: (value: number) => void) {}
+
+      // Throws if React calls it detached from the subscription object.
+      unsubscribe() {
+        this.closed = true
+        listeners.delete(this.listener)
+      }
+    }
+
+    const source = {
+      get: () => 1,
+      subscribe: (listener: (value: number) => void) => {
+        listeners.add(listener)
+        return new Subscription(listener)
+      },
+    }
+
+    function Comp() {
+      const value = useSelector(source)
+
+      return <p>Value: {value}</p>
+    }
+
+    const { getByText, unmount } = render(<Comp />)
+
+    expect(getByText('Value: 1')).toBeInTheDocument()
+    expect(listeners.size).toBe(1)
+
+    unmount()
+
+    expect(listeners.size).toBe(0)
+  })
+})
+
 describe('useStore', () => {
   it('is a compatibility alias for useSelector', async () => {
     const store = createStore(0)

--- a/packages/react-store/tests/index.test.tsx
+++ b/packages/react-store/tests/index.test.tsx
@@ -814,6 +814,109 @@ describe('useSelector subscription cleanup', () => {
 
     expect(listeners.size).toBe(0)
   })
+
+  it('moves the subscription when the source changes', () => {
+    function createSource(initial: number) {
+      const listeners = new Set<(value: number) => void>()
+      let value = initial
+
+      return {
+        listeners,
+        get: () => value,
+        set: (next: number) => {
+          value = next
+          listeners.forEach((listener) => listener(next))
+        },
+        subscribe: (listener: (value: number) => void) => {
+          listeners.add(listener)
+          return {
+            unsubscribe: () => {
+              listeners.delete(listener)
+            },
+          }
+        },
+      }
+    }
+
+    const first = createSource(1)
+    const second = createSource(10)
+
+    function Comp({ source }: { source: typeof first }) {
+      const value = useSelector(source)
+
+      return <p>Value: {value}</p>
+    }
+
+    const { getByText, rerender } = render(<Comp source={first} />)
+
+    expect(getByText('Value: 1')).toBeInTheDocument()
+    expect(first.listeners.size).toBe(1)
+
+    rerender(<Comp source={second} />)
+
+    expect(getByText('Value: 10')).toBeInTheDocument()
+    expect(first.listeners.size).toBe(0)
+    expect(second.listeners.size).toBe(1)
+
+    act(() => {
+      second.set(20)
+    })
+
+    expect(getByText('Value: 20')).toBeInTheDocument()
+  })
+})
+
+describe('useSelector compare changes', () => {
+  it('uses the compare function from the latest render', () => {
+    type State = { a: number; b: number }
+    const store = createStore<State>({ a: 0, b: 0 })
+    const compareA = (x: State, y: State) => x.a === y.a
+    const compareB = (x: State, y: State) => x.b === y.b
+    const renderSpy = vi.fn()
+
+    function Comp({ compare }: { compare: typeof compareA }) {
+      const value = useSelector(store, undefined, { compare })
+      renderSpy()
+
+      return (
+        <p>
+          a{value.a} b{value.b}
+        </p>
+      )
+    }
+
+    const { getByText, rerender } = render(<Comp compare={compareA} />)
+
+    expect(getByText('a0 b0')).toBeInTheDocument()
+
+    // compareA ignores `b`, so this update does not re-render.
+    act(() => {
+      store.setState((prev) => ({ ...prev, b: 1 }))
+    })
+
+    expect(getByText('a0 b0')).toBeInTheDocument()
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+
+    rerender(<Comp compare={compareB} />)
+
+    expect(getByText('a0 b1')).toBeInTheDocument()
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+
+    // compareB ignores `a`, so this update does not re-render.
+    act(() => {
+      store.setState((prev) => ({ ...prev, a: 1 }))
+    })
+
+    expect(getByText('a0 b1')).toBeInTheDocument()
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+
+    act(() => {
+      store.setState((prev) => ({ ...prev, b: 2 }))
+    })
+
+    expect(getByText('a1 b2')).toBeInTheDocument()
+    expect(renderSpy).toHaveBeenCalledTimes(3)
+  })
 })
 
 describe('useStore', () => {

--- a/packages/react-store/tests/index.test.tsx
+++ b/packages/react-store/tests/index.test.tsx
@@ -637,6 +637,144 @@ describe('store hooks', () => {
   })
 })
 
+describe('useSelector selection memo', () => {
+  type State = { a: number; b: number }
+
+  it('does not re-run a stable selector when the component re-renders with an unchanged store value', () => {
+    const store = createStore<State>({ a: 1, b: 2 })
+    const selector = vi.fn((state: State) => state.a)
+
+    function Comp({ label }: { label: string }) {
+      const value = useSelector(store, selector)
+
+      return (
+        <p>
+          {label}: {value}
+        </p>
+      )
+    }
+
+    const { getByText, rerender } = render(<Comp label="First" />)
+
+    expect(getByText('First: 1')).toBeInTheDocument()
+    expect(selector).toHaveBeenCalledTimes(1)
+
+    rerender(<Comp label="Second" />)
+
+    expect(getByText('Second: 1')).toBeInTheDocument()
+    expect(selector).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the previous selection identity when compare returns true', () => {
+    const store = createStore({ items: [1, 2], other: 0 })
+    const selections: Array<{ items: Array<number> }> = []
+
+    function Comp() {
+      const selected = useSelector(store, (state) => ({ items: state.items }), {
+        compare: shallow,
+      })
+      selections.push(selected)
+
+      return <p>Items: {selected.items.join(',')}</p>
+    }
+
+    const { getByText, rerender } = render(<Comp />)
+
+    expect(getByText('Items: 1,2')).toBeInTheDocument()
+    expect(selections).toHaveLength(1)
+
+    // The selection is shallowly equal, so the component must not re-render.
+    act(() => {
+      store.setState((prev) => ({ ...prev, other: 1 }))
+    })
+
+    expect(selections).toHaveLength(1)
+
+    // The inline selector has a new identity on every render; compare still
+    // runs against the previous selection so the component receives the same
+    // object.
+    rerender(<Comp />)
+
+    expect(selections).toHaveLength(2)
+    expect(selections[1]).toBe(selections[0])
+
+    act(() => {
+      store.setState((prev) => ({ ...prev, items: [...prev.items, 3] }))
+    })
+
+    expect(getByText('Items: 1,2,3')).toBeInTheDocument()
+    expect(selections).toHaveLength(3)
+    expect(selections[2]).not.toBe(selections[0])
+  })
+
+  it('re-runs a new selector and returns its selection', () => {
+    const store = createStore<State>({ a: 1, b: 2 })
+    const selectA = vi.fn((state: State) => state.a)
+    const selectB = vi.fn((state: State) => state.b)
+
+    function Comp({ selector }: { selector: (state: State) => number }) {
+      const value = useSelector(store, selector)
+
+      return <p>Value: {value}</p>
+    }
+
+    const { getByText, rerender } = render(<Comp selector={selectA} />)
+
+    expect(getByText('Value: 1')).toBeInTheDocument()
+    expect(selectA).toHaveBeenCalledTimes(1)
+    expect(selectB).not.toHaveBeenCalled()
+
+    rerender(<Comp selector={selectB} />)
+
+    expect(getByText('Value: 2')).toBeInTheDocument()
+    expect(selectA).toHaveBeenCalledTimes(1)
+    expect(selectB).toHaveBeenCalledTimes(1)
+
+    rerender(<Comp selector={selectA} />)
+
+    expect(getByText('Value: 1')).toBeInTheDocument()
+    expect(selectA).toHaveBeenCalledTimes(2)
+    expect(selectB).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-runs the installed selector exactly once per store update', () => {
+    const store = createStore<State>({ a: 1, b: 2 })
+    const selector = vi.fn((state: State) => state.a)
+    const renderSpy = vi.fn()
+
+    function Comp() {
+      const value = useSelector(store, selector)
+      renderSpy()
+
+      return <p>Value: {value}</p>
+    }
+
+    const { getByText } = render(<Comp />)
+
+    expect(getByText('Value: 1')).toBeInTheDocument()
+    expect(selector).toHaveBeenCalledTimes(1)
+    expect(renderSpy).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      store.setState((prev) => ({ ...prev, a: 10 }))
+    })
+
+    expect(getByText('Value: 10')).toBeInTheDocument()
+    expect(selector).toHaveBeenCalledTimes(2)
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+
+    // An update that leaves the selection unchanged still runs the selector once
+    // to find that out, but does not re-render.
+    act(() => {
+      store.setState((prev) => ({ ...prev, b: 20 }))
+    })
+
+    expect(getByText('Value: 10')).toBeInTheDocument()
+    expect(selector).toHaveBeenCalledTimes(3)
+    expect(renderSpy).toHaveBeenCalledTimes(2)
+  })
+})
+
 describe('useStore', () => {
   it('is a compatibility alias for useSelector', async () => {
     const store = createStore(0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1139,9 +1139,6 @@ importers:
       '@tanstack/store':
         specifier: workspace:*
         version: link:../store
-      use-sync-external-store:
-        specifier: ^1.6.0
-        version: 1.6.0(react@19.2.5)
     devDependencies:
       '@testing-library/react':
         specifier: ^16.3.2
@@ -1152,9 +1149,6 @@ importers:
       '@types/react-dom':
         specifier: ^19.2.3
         version: 19.2.3(@types/react@19.2.17)
-      '@types/use-sync-external-store':
-        specifier: ^1.5.0
-        version: 1.5.0
       '@vitejs/plugin-react':
         specifier: ^6.0.1
         version: 6.0.1(vite@8.1.5(@types/node@25.6.0)(esbuild@0.27.7)(jiti@2.6.1)(less@4.4.2)(sass@1.97.3)(terser@5.46.0)(yaml@2.9.0))
@@ -4490,8 +4484,6 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
-  '@types/use-sync-external-store@1.5.0':
-    resolution: {integrity: sha512-5dyB8nLC/qogMrlCizZnYWQTA4lnb/v+It+sqNl5YnSRAPMlIqY/X0Xn+gZw8vOL+TgTTr28VEbn3uf8fUtAkw==}
 
   '@types/ws@8.18.1':
     resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
@@ -8790,10 +8782,6 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  use-sync-external-store@1.6.0:
-    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -12560,7 +12548,6 @@ snapshots:
 
   '@types/unist@3.0.3': {}
 
-  '@types/use-sync-external-store@1.5.0': {}
 
   '@types/ws@8.18.1':
     dependencies:
@@ -17672,9 +17659,6 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-sync-external-store@1.6.0(react@19.2.5):
-    dependencies:
-      react: 19.2.5
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## 🎯 Changes

> **Breaking (per review):** `@tanstack/react-store` now requires **React 18 or newer**. `peerDependencies` are `react` / `react-dom` `^18.0.0 || ^19.0.0`; React 16.8 and 17 are no longer supported. This lets the package use React's built-in `useSyncExternalStore` and drop the `use-sync-external-store` dependency entirely. The changeset is `major` and the repo enters changesets pre mode with the `alpha` tag, so this releases as **`@tanstack/react-store@1.0.0-alpha.0`**.

`useSelector` in `@tanstack/react-store` wrapped `use-sync-external-store/shim/with-selector`. Per subscribed component and per render that stack ran two `useCallback`s in `useSelector` (`subscribe`, `getSnapshot`) plus, inside the with-selector shim, a `useRef`, a `useMemo` with four deps that rebuilt the memoized selector whenever the (usually inline) selector changed identity, a `useEffect` copying the committed value into the ref, `useDebugValue`, and finally `useSyncExternalStore`. That is about seven hook slots and six allocations per render, and a passive effect React has to traverse on every commit, for every component that calls `useSelector`.

**Measured in TanStack Router with 200 mounted `<Link>`s** (macOS arm64, Node 24.8.0; `<Link>` calls `useSelector` once per link): a replacement built on a plain `useSyncExternalStore` and a single ref reduced retained heap by 8% (2738 → 2512 KB) and re-render CPU by about 5% on renders that recompute the selection. Router can't ship that privately (27 call sites would keep the shim in the bundle), so this lands upstream.

### What changed

- `useSelector` now calls React's built-in `useSyncExternalStore` (available since React 18). The `use-sync-external-store` dependency and `@types/use-sync-external-store` are removed; the lockfile change is limited to those entries.
- **One `useRef` holds one flat, in-place-mutated object**: the `subscribe` and `getSnapshot` callbacks together with the `source`, `selector` and `compare` they were built for, plus the last selection (`owner`, `snapshot`, `selected`). `subscribe` is rebuilt only when the source changes and `getSnapshot` only when source, selector or compare change. No `useCallback`s: React clones every hook object on each re-render and `useCallback` allocates its closure and deps array every time, so the hook went from three own slots to one.
- **`getSnapshot` is identity-stable while its inputs are stable.** React compares `getSnapshot` by identity; whenever it changes it flags the fiber for passive effects, pushes an `updateStoreInstance` effect (plus a `bind`) and, in transitions, a store consistency check that calls `getSnapshot` again. With a stable selector, a re-render that leaves the store untouched now costs no allocations and no effects in `useSelector`.
- **The selection is keyed on the `getSnapshot` closure that computed it** (`owner`). That closure captures the source, selector and compare it was built for, so a memo hit is two identity checks (`owner`, `snapshot`) and no selector/compare fields are needed on the record. On a miss it runs the selector and, when `compare(previous, next)` is true, keeps the previous selection so `useSyncExternalStore` sees an unchanged value and skips the re-render. Inline selectors allocate exactly one closure per render.
- The subscription cleanup calls `subscription.unsubscribe()` on the subscription object instead of handing React the detached method (pre-existing issue flagged by CodeRabbit: a `SelectionSource` whose `unsubscribe` relies on `this` threw during cleanup and stayed subscribed).
- The default identity selector is hoisted to a module-level function so `useSelector(atom)` (no selector) takes the stable path.
- `_useStore`, `useAtom` and `useStore` only call `useSelector` and needed no changes. `preact-store` is untouched (it has its own shim).
- `docs/installation.md` now states React v18+ and no longer claims ReactDOM-only support (React Native works too).
- Release plumbing: `.changeset/pre.json` (`changeset pre enter alpha`) and the changeset bumped to `major`. `changeset status` reports `@tanstack/react-store 1.0.0-alpha.0`; a local dry run of `changeset version` produced `1.0.0-alpha.0` with the expected changelog entry. Note that while `pre.json` exists, every package that receives a changeset is versioned as an `-alpha.N` prerelease; run `pnpm changeset pre exit` to return to normal releases.

### Semantics preserved

- Public signature and types are unchanged: `useSelector(source, selector = identity, options?: { compare })`, default compare `===`, `SelectionSource` shape and exported `UseSelectorOptions` unchanged.
- Both closures **capture** their inputs instead of reading them from the ref, and the selection is keyed on the closure. A render that suspends with a different selector (a transition) therefore cannot change what the committed subscription selects, and cannot poison the committed selector's memo. The existing test `useSelector keeps the committed selector active while a selector change suspends` passes unchanged; dropping the `owner` check makes it, the selector-switch test and the compare-change test fail (verified by mutation).
- As in the with-selector shim (which compared the first result of every rebuilt memoized selector against the last committed `inst.value`), `compare` runs against the previous selection regardless of which selector produced it. That is what keeps inline selectors such as `useSelector(store, (s) => ({ items: s.items }), { compare: shallow })` identity-stable across parent re-renders.
- Because the closure captures `compare`, a render with a different `compare` gets a new closure and therefore a memo miss, as the shim's memo (keyed on `isEqual`) did. A test pins this and fails on the first commits of this PR, where the record was keyed on the selector only.
- `getSnapshot` results are cached per closure and snapshot, so React's dev-mode "The result of getSnapshot should be cached" check stays quiet.
- The only dropped hook is the shim's `useDebugValue(value)`, which only affected the React DevTools display of the hook value.

### Tests added (`packages/react-store/tests/index.test.tsx`)

`describe('useSelector selection memo')`:

1. A stable selector is not re-run when the component re-renders with an unchanged store value.
2. `compare` returning true keeps the previous selection identity and does not re-render, including across a re-render with a new inline selector identity (`selections[1]` is `selections[0]`).
3. Switching to a new selector re-runs it exactly once and returns its selection; switching back re-runs the first selector.
4. A store update re-runs the installed selector exactly once per update, and an update that leaves the selection unchanged runs it once without re-rendering.

`describe('useSelector subscription cleanup')`:

5. A source returning a class-based subscription whose `unsubscribe` uses `this` is cleaned up on unmount (failed with `TypeError: Cannot set properties of undefined (setting 'closed')` before the fix).
6. Switching `source` moves the subscription (old source has 0 listeners, new has 1) and reads and follows the new source.

`describe('useSelector compare changes')`:

7. The `compare` function from the latest render is used (fails on the first commits of this PR, see above).

### Verification

Run one at a time with `CI=1 NX_DAEMON=false pnpm nx run @tanstack/react-store:<target> --outputStyle=stream --skip-nx-cache`:

- `test:lib` (vitest): 2 files, **52 passed** (45 existing unchanged + 7 new), type errors: none
- `test:types`: TS 5.6, 5.7, 5.8 and 6.0 all pass
- `test:eslint`: 0 problems
- `test:build` (publint --strict): no issues
- `pnpm test:knip`, `pnpm test:sherif`: no issues; `pnpm install --frozen-lockfile` succeeds with the trimmed lockfile

### Performance

Throwaway vitest bench (not committed; the repo has no benchmark convention): production React 19.2.5, jsdom, 200 subscribed components, `flushSync` renders, mean per operation. "useCallback version" is the earlier commit of this PR (`useCallback` × 2 + `useRef`, per-render `getSnapshot`).

| scenario (200 components) | useCallback version | single ref | |
|---|---|---|---|
| parent re-render, stable selectors, store unchanged | 0.164 ms | 0.128 ms | **−22%** |
| parent re-render, inline selectors, store unchanged | 0.161 ms | 0.153 ms | −5% |
| store update re-rendering all components | 0.203 ms | 0.188 ms | −8% |
| mount + unmount | 0.795 ms | 0.732 ms | −8% |

A variant that kept two `useCallback`s and keyed `getSnapshot` on `[source, selector, compare]` was *slower* than the useCallback version (the extra hook slot and deps compare cost more than the skipped effect saves), which is why the single-ref approach was chosen. The final flattening (one object, closure-keyed memo) removes a further allocation per inline render and per mount and halves the memo-hit comparisons; at 200 components that is inside the bench's ±3–8% noise, since the hook is now a small fraction of React's per-component work.

### Bundle size

The package builds unbundled; `dist/index.js` is a barrel (unchanged at 480 B) and the memo now lives in `dist/useSelector.js`. What consumers ship, measured with rolldown (`--minify --format esm`, `NODE_ENV=production`, `react`/`@tanstack/store` external):

| react-store as shipped to consumers | raw | gzip |
|---|---|---|
| main (react-store + `use-sync-external-store` shim + with-selector) | 3385 B | 1510 B |
| this PR | 1443 B | 676 B |
| delta vs main | **−1942 B (−57%)** | **−834 B (−55%)** |

`useSelector` alone is 595 B / 343 B gzip minified.

## ✅ Checklist

- [x] I have followed the steps in the [Contributing guide](https://github.com/TanStack/store/blob/main/CONTRIBUTING.md).
- [x] I have tested this code locally with `pnpm test:pr`.

## 🚀 Release Impact

- [x] This change affects published code, and I have generated a [changeset](https://github.com/changesets/changesets/blob/main/docs/adding-a-changeset.md) (`major`, released as `1.0.0-alpha.0` via changesets pre mode).
- [ ] This change is docs/CI/dev-only (no release).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Improved `useSelector` memoization across re-renders, selector changes, and store updates.
  - Preserved selected value identity when comparisons indicate no meaningful change.

- **Bug Fixes**
  - Improved subscription cleanup, including sources whose unsubscribe behavior depends on subscription context.
  - Ensured the latest comparison function is used after updates.

- **Breaking Changes**
  - `@tanstack/react-store` now requires React 18 or React 19. React 16.8 and React 17 are no longer supported.

- **Documentation**
  - Updated React compatibility requirements and `useSelector` API reference details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
